### PR TITLE
Migrate the copy-paste-detection setup to jscpd 5.x

### DIFF
--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,20 +1,20 @@
 {
-    "languages": [
+    "format": [
         "php",
         "javascript"
     ],
     "threshold": 0,
     "reporters": [
-        "consoleFull"
+        "console-full"
     ],
     "minTokens": 100,
     "minLines": 5,
     "path": [
-        "src/",
-        "resources/js/modules/"
+        "src",
+        "resources/js/modules"
     ],
     "ignore": [
         "**/*.min.js"
     ],
-    "exitCode": true
+    "exitCode": 1
 }

--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,7 @@
             "@ci:rector --dry-run"
         ],
         "ci:test:cpd": [
-            "npx jscpd src resources/js/modules --config .jscpd.json"
+            "npx jscpd src resources/js/modules --config .jscpd.json --skip-comments --no-tips"
         ],
         "ci:test:php:unit": [
             "phpunit --configuration phpunit.xml --display-all-issues"

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
                 "d3-zoom": "^3.0",
                 "jest": "^30.4",
                 "jest-environment-jsdom": "^30.4",
-                "jscpd": "^4.2.5",
+                "jscpd": "^5.0.9",
                 "rollup": "^4.61",
                 "rollup-plugin-license": "^3.0",
                 "typescript": "^6.0.3"
@@ -722,17 +722,6 @@
                 "node": ">=14.21.3"
             }
         },
-        "node_modules/@colors/colors": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-            "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=0.1.90"
-            }
-        },
         "node_modules/@csstools/color-helpers": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
@@ -1345,74 +1334,9 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
-        "node_modules/@jscpd/badge-reporter": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@jscpd/badge-reporter/-/badge-reporter-4.2.5.tgz",
-            "integrity": "sha512-ktXrjPeRaRyUDktxTroSA2/w5sshXpQplWkUuq/e6XqEpKBSbGEnwZLIaegSijOrMwIcCXPQ9k4feXIz5eVJNA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "badgen": "^3.2.3",
-                "colors": "^1.4.0",
-                "fs-extra": "^11.2.0"
-            }
-        },
-        "node_modules/@jscpd/core": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@jscpd/core/-/core-4.2.5.tgz",
-            "integrity": "sha512-Esf2deHxaoNEjePwf2jqP6Urzj+BAOsJVPFLbnnSsV+q7rLNMcn0UEEoKBXIOOt4qMkrkhl9DfwpMyPPOr6GkQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "eventemitter3": "^5.0.1"
-            }
-        },
-        "node_modules/@jscpd/finder": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@jscpd/finder/-/finder-4.2.5.tgz",
-            "integrity": "sha512-Rw0dtwp/EeLANbujOubuQeJIuXXXkAlT+f5geZhwkB9TxEYP0hqNrdOJUK/TDBKQjRGrOizEtdNy+S4UlbdzOQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jscpd/core": "4.2.5",
-                "@jscpd/tokenizer": "4.2.5",
-                "blamer": "^1.0.6",
-                "bytes": "^3.1.2",
-                "cli-table3": "^0.6.5",
-                "colors": "^1.4.0",
-                "fast-glob": "^3.3.2",
-                "fs-extra": "^11.2.0",
-                "markdown-table": "^2.0.0",
-                "pug": "^3.0.4"
-            }
-        },
-        "node_modules/@jscpd/html-reporter": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@jscpd/html-reporter/-/html-reporter-4.2.5.tgz",
-            "integrity": "sha512-zMMIKbvi43dMgeNeHXlHQy1ovf+KJrzNlUubaBvCAVatqP23ksW8d3fmsevIQG9mMMTH0D1xOz+SxUn1FREOPg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "colors": "1.4.0",
-                "fs-extra": "^11.2.0",
-                "pug": "^3.0.4"
-            }
-        },
-        "node_modules/@jscpd/tokenizer": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@jscpd/tokenizer/-/tokenizer-4.2.5.tgz",
-            "integrity": "sha512-UM8Wx/jwahmflqQExlcKMQTYOAy58N/fn7Pv6NYrkD3EZm/FTk7gW97wkXy5aDE1Ts9oBUpT9tLY2rz7ogCHAQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jscpd/core": "4.2.5",
-                "spark-md5": "^3.0.2"
-            }
-        },
         "node_modules/@magicsunday/webtrees-chart-lib": {
-            "version": "1.14.0",
-            "resolved": "git+ssh://git@github.com/magicsunday/webtrees-chart-lib.git#3f5235a6da125316704bfd5d5de62fc25f23723d",
-            "integrity": "sha512-zw+58Vr2tii80IOTaoP1Pm++/5AcxbTK90O5NLHr0QUHtu9m/ktyLLodCZ1X+BMChhXcFvxfWkrBuiM+k7rC9g==",
+            "version": "1.13.0",
+            "resolved": "git+ssh://git@github.com/magicsunday/webtrees-chart-lib.git#15d334f8943cf4d3865bae0fe4a6b60febbf631b",
             "license": "GPL-3.0-or-later",
             "peerDependencies": {
                 "d3-array": "^3.2.4",
@@ -1450,44 +1374,6 @@
             "peerDependencies": {
                 "@emnapi/core": "^1.7.1",
                 "@emnapi/runtime": "^1.7.1"
-            }
-        },
-        "node_modules/@nodelib/fs.scandir": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@nodelib/fs.stat": "2.0.5",
-                "run-parallel": "^1.1.9"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/@nodelib/fs.stat": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/@nodelib/fs.walk": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@nodelib/fs.scandir": "2.1.5",
-                "fastq": "^1.6.0"
-            },
-            "engines": {
-                "node": ">= 8"
             }
         },
         "node_modules/@pkgjs/parseargs": {
@@ -1580,9 +1466,9 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.1.tgz",
-            "integrity": "sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==",
+            "version": "4.61.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.0.tgz",
+            "integrity": "sha512-dnxczajOqt0gesZlN5pGQ1s1imQVrsmCw5G2Ci4oM+0WvNz3pyRnlWrT7McoZIb8VlFwCawdmbWRmxRn7HI+VQ==",
             "cpu": [
                 "arm"
             ],
@@ -1594,9 +1480,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.1.tgz",
-            "integrity": "sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==",
+            "version": "4.61.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.0.tgz",
+            "integrity": "sha512-Bp3JpGP00Vu3f238ivRrjf7z3xSzVPXqCmaJYA9t2c+c8vKYvOzmXF7LkkeUalTEGd6cZcSWe+PFIP3Vy48fRg==",
             "cpu": [
                 "arm64"
             ],
@@ -1608,9 +1494,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.1.tgz",
-            "integrity": "sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==",
+            "version": "4.61.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.0.tgz",
+            "integrity": "sha512-zaYIpr670mUmmZ1tVzUFplbQbG7h3Gugx3L5FoqhsC2m/YnLlR1a7zVLmXNPy+iY1tFPEbNG+HHBXZGyId0G5w==",
             "cpu": [
                 "arm64"
             ],
@@ -1622,9 +1508,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.1.tgz",
-            "integrity": "sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==",
+            "version": "4.61.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.0.tgz",
+            "integrity": "sha512-+P49fvkv2dSoeevUW+lgZ/I2JHSsJCK1Lyjj7Cu6E4UHG4tS9XIefzIjo5qhgELjAclnen1rLzK2PMKJdo+Dyg==",
             "cpu": [
                 "x64"
             ],
@@ -1636,9 +1522,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.1.tgz",
-            "integrity": "sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==",
+            "version": "4.61.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.0.tgz",
+            "integrity": "sha512-l3FAAOyKJXH2ea6KNFN+MMgC/rnE94YGLXs2ehYqDcCoHt1DpvgWX75BhUJxN38XojP7Ul+4H8PRn7EdyqSDrw==",
             "cpu": [
                 "arm64"
             ],
@@ -1650,9 +1536,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.1.tgz",
-            "integrity": "sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==",
+            "version": "4.61.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.0.tgz",
+            "integrity": "sha512-VokPN3TSctKj65cyCNPaUh4vMFA8awxOot/0sp+4J7ZlNRKQEhXhawqPwajoi8H5ZFt61i0ugZJuTKXBjGJ17Q==",
             "cpu": [
                 "x64"
             ],
@@ -1664,9 +1550,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.1.tgz",
-            "integrity": "sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==",
+            "version": "4.61.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.0.tgz",
+            "integrity": "sha512-DxH0P3wxm+Yzs/p3zrk9dw1rURu8p0Nv5+MRK/L7OtnLNg5rLZraSBFZ8iUXOd9f2BlhJyEpIZUH/emjq4UJ4g==",
             "cpu": [
                 "arm"
             ],
@@ -1678,9 +1564,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.1.tgz",
-            "integrity": "sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==",
+            "version": "4.61.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.0.tgz",
+            "integrity": "sha512-T6ZvMNe84kAz6TBWHC7hGAoEtzP1LWYw/AqayGWEF6uISt3Abk/st06LqRD9THd7Xz3NxzurUpzAuEAUbZf+nw==",
             "cpu": [
                 "arm"
             ],
@@ -1692,9 +1578,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.1.tgz",
-            "integrity": "sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==",
+            "version": "4.61.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.0.tgz",
+            "integrity": "sha512-q/4hzvQkDs8b4jIBab1pnLiiM0ayTZsN2amBFPDzuyZxjEd4wDwx0UJFYM3cOZzSf5Kw8fnWSprJzIBMkcR44Q==",
             "cpu": [
                 "arm64"
             ],
@@ -1706,9 +1592,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.1.tgz",
-            "integrity": "sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==",
+            "version": "4.61.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.0.tgz",
+            "integrity": "sha512-vvYWX3akdEAY6km+9wAqFDnk6pQsbJKVnj7xawcvs/+fdlYBGp+U+Qq/lLfpIxYIZvZLHMAKD9HLdacSx/r3dw==",
             "cpu": [
                 "arm64"
             ],
@@ -1720,9 +1606,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loong64-gnu": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.1.tgz",
-            "integrity": "sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==",
+            "version": "4.61.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.0.tgz",
+            "integrity": "sha512-DePa5cqOxDP/Zp0VOXpeWaGew5iIv5DXp9NYbzkX5PFQyWVX9184WCTh3hvr/7lhXo8ZVlbFLkz8+o/q1dU6gA==",
             "cpu": [
                 "loong64"
             ],
@@ -1734,9 +1620,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loong64-musl": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.1.tgz",
-            "integrity": "sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==",
+            "version": "4.61.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.0.tgz",
+            "integrity": "sha512-LV8aWMB8UChglMCEzs7RkN0GsH29RJaLLqwm9fCIjlqwxQTiWAqNcc7wjBkH31hV0PU/yVxGYvrYsgfea2qw6g==",
             "cpu": [
                 "loong64"
             ],
@@ -1748,9 +1634,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.1.tgz",
-            "integrity": "sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==",
+            "version": "4.61.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.0.tgz",
+            "integrity": "sha512-QoNSnwQtaeNu5grdBbsL0tt1uyl5EnS8DA8Mr3nluMXbhdQNyhN+G4tBax7VCdxLKj8YJ0/4OO9Ho84jMnJtKA==",
             "cpu": [
                 "ppc64"
             ],
@@ -1762,9 +1648,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-musl": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.1.tgz",
-            "integrity": "sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==",
+            "version": "4.61.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.0.tgz",
+            "integrity": "sha512-/zZp5MKapIIApE8trN8qLGNSiRN9TUoaUZ1cmVu4XnVdd5LQLOXTtyi+vtfUbNnT3iyjzpPqYeKXmvJ+gJGYWw==",
             "cpu": [
                 "ppc64"
             ],
@@ -1776,9 +1662,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.1.tgz",
-            "integrity": "sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==",
+            "version": "4.61.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.0.tgz",
+            "integrity": "sha512-RbrzcD3aJ1k3UbtMRRBNwojdVVyXjuVAFTfn/xPa6EEl6GE9Sm/akPgFTb9aAC9pMKGJ6CtWxaGrqWcabH+ySg==",
             "cpu": [
                 "riscv64"
             ],
@@ -1790,9 +1676,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.1.tgz",
-            "integrity": "sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==",
+            "version": "4.61.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.0.tgz",
+            "integrity": "sha512-ZF+onDsBso8PJf1XaG9lB+O9RnBpKGnY6OrzC4CSHrtC1jb6jWLTKK4bRqdoCXHd22gyr2hiYmEAm8Wns/BOCw==",
             "cpu": [
                 "riscv64"
             ],
@@ -1804,9 +1690,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.1.tgz",
-            "integrity": "sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==",
+            "version": "4.61.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.0.tgz",
+            "integrity": "sha512-Atk0aSIk5Zx2Wuh9dgRQgLP0Koc8hOeYpbWryMXyk8G8/HmPkwPPkMqIIDhrXHHYqfUzSJA/I7IWSBv8xSmRBA==",
             "cpu": [
                 "s390x"
             ],
@@ -1818,9 +1704,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.1.tgz",
-            "integrity": "sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==",
+            "version": "4.61.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.0.tgz",
+            "integrity": "sha512-0uMOcf3eZ5K+K4cYHkdxShFMPlPXCOdfDFEFn9dNYAEEd2cVvmOfH7zFgRVoDgmtQ1m9k5q7qfrHzyMAubKYUA==",
             "cpu": [
                 "x64"
             ],
@@ -1832,9 +1718,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.1.tgz",
-            "integrity": "sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==",
+            "version": "4.61.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.0.tgz",
+            "integrity": "sha512-mvFtE4A/t/7hRJ7X8Ozmu8FsIkAUat2nzl12pgU337BRmq87AQUJztwHz2Zv5/tjo9/C95E66CK03SI/ToEDJw==",
             "cpu": [
                 "x64"
             ],
@@ -1846,9 +1732,9 @@
             ]
         },
         "node_modules/@rollup/rollup-openbsd-x64": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.1.tgz",
-            "integrity": "sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==",
+            "version": "4.61.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.0.tgz",
+            "integrity": "sha512-z9b9+aTxvt8n2rNltMPvyaUfB8NJ+CVyOrGK/MdIKHx7B+lXmZpm/XbRsU7Rpf3fRqJ2uS6mBJiJveCtq8LHDg==",
             "cpu": [
                 "x64"
             ],
@@ -1860,9 +1746,9 @@
             ]
         },
         "node_modules/@rollup/rollup-openharmony-arm64": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.1.tgz",
-            "integrity": "sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==",
+            "version": "4.61.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.0.tgz",
+            "integrity": "sha512-jXaXFqKMehsOc+g8R6oo33RRC6w07G9jDBxAE5eAKX7mOcCbZloYIPNhfG9Wl+P9O9IWHFO4OJgPi1Ml2qkt7w==",
             "cpu": [
                 "arm64"
             ],
@@ -1874,9 +1760,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.1.tgz",
-            "integrity": "sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==",
+            "version": "4.61.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.0.tgz",
+            "integrity": "sha512-OXNWVFocS2IA4+QplhTZZ2a+8hPZR7T8KuozsNmJKK8y7cp83StHvGksfHzPG3wczWTczyWHVQuqeiTUbjiyBg==",
             "cpu": [
                 "arm64"
             ],
@@ -1888,9 +1774,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.1.tgz",
-            "integrity": "sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==",
+            "version": "4.61.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.0.tgz",
+            "integrity": "sha512-AlAbNtBO637LxSldqV43z0FfXoGfl2TW1DgAg/bs7aQswFbDewz2SJm3BUhiGfbOVtW571xbc9p+REdxhyN/Eg==",
             "cpu": [
                 "ia32"
             ],
@@ -1902,9 +1788,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-gnu": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.1.tgz",
-            "integrity": "sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==",
+            "version": "4.61.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.0.tgz",
+            "integrity": "sha512-QRSrQXyJ1M4tjNXdR0/G/IgV6lzfQQJYBjlWIEYkY2Xs86DRl/iEpQ4blMDjJxSl7n19eDKKXMg0AmuBVYy8pQ==",
             "cpu": [
                 "x64"
             ],
@@ -1916,9 +1802,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.1.tgz",
-            "integrity": "sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==",
+            "version": "4.61.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.0.tgz",
+            "integrity": "sha512-tkuFxhvKO/HlGd0VsINF6vHSYH8AF8W0TcNxKDK6JZmrehngFj78pToc8iemtnvwilDjs2G/qSzYFhe9U8q+fw==",
             "cpu": [
                 "x64"
             ],
@@ -2151,13 +2037,6 @@
         },
         "node_modules/@types/resolve": {
             "version": "1.20.2",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@types/sarif": {
-            "version": "2.1.7",
-            "resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz",
-            "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -2506,19 +2385,6 @@
                 "win32"
             ]
         },
-        "node_modules/acorn": {
-            "version": "7.4.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-            "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "acorn": "bin/acorn"
-            },
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
         "node_modules/agent-base": {
             "version": "7.1.4",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -2616,20 +2482,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/asap": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-            "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/assert-never": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.4.0.tgz",
-            "integrity": "sha512-5oJg84os6NMQNl27T9LnZkvvqzvAnHu03ShCnoj6bsJwS7L8AO4lf+C/XjK/nvzEqQB744moC6V128RucQd1jA==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/babel-jest": {
             "version": "30.4.1",
@@ -2730,26 +2582,6 @@
                 "@babel/core": "^7.11.0 || ^8.0.0-beta.1"
             }
         },
-        "node_modules/babel-walk": {
-            "version": "3.0.0-canary-5",
-            "resolved": "https://registry.npmjs.org/babel-walk/-/babel-walk-3.0.0-canary-5.tgz",
-            "integrity": "sha512-GAwkz0AihzY5bkwIY5QDR+LvsRQgB/B+1foMPvi0FZPMl5fjD7ICiznUiBdLYMH1QYe6vqu4gWYytZOccLouFw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.9.6"
-            },
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
-        "node_modules/badgen": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/badgen/-/badgen-3.3.2.tgz",
-            "integrity": "sha512-fbQwK9norfdzbdsoPwbLIAmgBXDGEme3jeIyqPAH7o6vp9lmuLHS7uXULvOiQ6XnMLkYNG4gDjILf74hgtTAug==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2770,77 +2602,6 @@
                 "node": ">=6.0.0"
             }
         },
-        "node_modules/blamer": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/blamer/-/blamer-1.0.7.tgz",
-            "integrity": "sha512-GbBStl/EVlSWkiJQBZps3H1iARBrC7vt++Jb/TTmCNu/jZ04VW7tSN1nScbFXBUy1AN+jzeL7Zep9sbQxLhXKA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "execa": "^4.0.0",
-                "which": "^2.0.2"
-            },
-            "engines": {
-                "node": ">=8.9"
-            }
-        },
-        "node_modules/blamer/node_modules/execa": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-            "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cross-spawn": "^7.0.0",
-                "get-stream": "^5.0.0",
-                "human-signals": "^1.1.1",
-                "is-stream": "^2.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^4.0.0",
-                "onetime": "^5.1.0",
-                "signal-exit": "^3.0.2",
-                "strip-final-newline": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
-            }
-        },
-        "node_modules/blamer/node_modules/get-stream": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-            "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "pump": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/blamer/node_modules/human-signals": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-            "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=8.12.0"
-            }
-        },
-        "node_modules/blamer/node_modules/signal-exit": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-            "dev": true,
-            "license": "ISC"
-        },
         "node_modules/brace-expansion": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
@@ -2849,19 +2610,6 @@
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/braces": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fill-range": "^7.1.1"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/browserslist": {
@@ -2912,47 +2660,6 @@
             "version": "1.1.2",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/bytes": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-            "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/call-bind-apply-helpers": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "function-bind": "^1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/call-bound": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.2",
-                "get-intrinsic": "^1.3.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
         },
         "node_modules/callsites": {
             "version": "3.1.0",
@@ -3020,16 +2727,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/character-parser": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
-            "integrity": "sha512-+UqJQjFEFaTAs3bNsF2j2kEN1baG/zghZbdqoYEDxGZtJo9LBzl1A+m0D4n3qKx8N2FNv8/Xp6yV9mQmBuptaw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-regex": "^1.0.3"
-            }
-        },
         "node_modules/ci-info": {
             "version": "4.4.0",
             "dev": true,
@@ -3050,67 +2747,6 @@
             "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/cli-table3": {
-            "version": "0.6.5",
-            "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
-            "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "string-width": "^4.2.0"
-            },
-            "engines": {
-                "node": "10.* || >= 12.*"
-            },
-            "optionalDependencies": {
-                "@colors/colors": "1.5.0"
-            }
-        },
-        "node_modules/cli-table3/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cli-table3/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/cli-table3/node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cli-table3/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
         },
         "node_modules/cliui": {
             "version": "8.0.1",
@@ -3224,16 +2860,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/colors": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-            "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.1.90"
-            }
-        },
         "node_modules/commander": {
             "version": "7.2.0",
             "dev": true,
@@ -3254,23 +2880,105 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/constantinople": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
-            "integrity": "sha512-vCrqcSIq4//Gx74TXXCGnHpulY1dskqLTFGDmhrGxzeXL8lF8kvXv6mpNWlJj1uD4DW23D4ljAqbY4RRaaUZIw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.6.0",
-                "@babel/types": "^7.6.1"
-            }
-        },
         "node_modules/convert-source-map": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
             "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/cpd-darwin-arm64": {
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/cpd-darwin-arm64/-/cpd-darwin-arm64-5.0.9.tgz",
+            "integrity": "sha512-hUYQKrUUmlYxl2MDD8GYESpcKc5M5eGMjiHTK+O8ooCj1ogPiNHXg+aIeDl6BuLu7v3jFDcCu5fVqtcpHzAKpw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/cpd-darwin-x64": {
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/cpd-darwin-x64/-/cpd-darwin-x64-5.0.9.tgz",
+            "integrity": "sha512-viCFEUhUQnGundSMFq9ixi+RxfRiNDQsWP/CZErMlf20fM5h9zTtrHI9liNyRQn+ZtQUTTpabQ4PpzDV530bMg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/cpd-linux-arm64-gnu": {
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/cpd-linux-arm64-gnu/-/cpd-linux-arm64-gnu-5.0.9.tgz",
+            "integrity": "sha512-BxiLx9haM+AhDlkyFoe1ro1w4/dvAteyEGytv4XraaRNntw2NMFX1Fsa9I8waegpXydM6E0lPWRWqkG59rin3A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/cpd-linux-x64-gnu": {
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/cpd-linux-x64-gnu/-/cpd-linux-x64-gnu-5.0.9.tgz",
+            "integrity": "sha512-VC2bUEJ0KRZ3fJijqqFcrBl6a69vmHrrNoJkSPtFwFju8x7ce2Vs9ntEmlxeB7Ho4mIzN8OYOrlCeqyNdAZcUA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/cpd-linux-x64-musl": {
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/cpd-linux-x64-musl/-/cpd-linux-x64-musl-5.0.9.tgz",
+            "integrity": "sha512-YJekKRRgAhez2+Rrbt42fp8cJuNi/PtGuBb8jIzEtegXRRBG9CE9HaoTy0mS3JeiQuwxiT0Fnz2j8hR9gDbq0w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/cpd-windows-x64-msvc": {
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/cpd-windows-x64-msvc/-/cpd-windows-x64-msvc-5.0.9.tgz",
+            "integrity": "sha512-Z54yLFmRjIgTMqzeUxbZzgxj8gWxB/jjMi/QOkBOLx9yHHwzhW8MukpY7JhCOmlvPOOn6pjSVrMTxChliDcYAw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
@@ -3678,28 +3386,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/doctypes": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
-            "integrity": "sha512-LLBi6pEqS6Do3EKQ3J0NqHWV5hhb78Pi8vvESYwyOy2c31ZEZVdtitdzsQsKb7878PEERhzUk0ftqGhG6Mz+pQ==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/dunder-proto": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.1",
-                "es-errors": "^1.3.0",
-                "gopd": "^1.2.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/eastasianwidth": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -3734,16 +3420,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/end-of-stream": {
-            "version": "1.4.5",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-            "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "once": "^1.4.0"
-            }
-        },
         "node_modules/entities": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
@@ -3767,33 +3443,10 @@
                 "is-arrayish": "^0.2.1"
             }
         },
-        "node_modules/es-define-property": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/es-errors": {
             "version": "1.3.0",
             "dev": true,
             "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-object-atoms": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
-            "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0"
-            },
             "engines": {
                 "node": ">= 0.4"
             }
@@ -3832,13 +3485,6 @@
         },
         "node_modules/estree-walker": {
             "version": "2.0.2",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/eventemitter3": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
-            "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
             "dev": true,
             "license": "MIT"
         },
@@ -3901,39 +3547,12 @@
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
-        "node_modules/fast-glob": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-            "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@nodelib/fs.stat": "^2.0.2",
-                "@nodelib/fs.walk": "^1.2.3",
-                "glob-parent": "^5.1.2",
-                "merge2": "^1.3.0",
-                "micromatch": "^4.0.8"
-            },
-            "engines": {
-                "node": ">=8.6.0"
-            }
-        },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/fastq": {
-            "version": "1.20.1",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
-            "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "reusify": "^1.0.4"
-            }
         },
         "node_modules/fb-watchman": {
             "version": "2.0.2",
@@ -3959,19 +3578,6 @@
                 "picomatch": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/fill-range": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "to-regex-range": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/find-up": {
@@ -4003,21 +3609,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/fs-extra": {
-            "version": "11.3.5",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
-            "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14.14"
             }
         },
         "node_modules/fs.realpath": {
@@ -4070,31 +3661,6 @@
                 "node": "6.* || 8.* || >= 10.*"
             }
         },
-        "node_modules/get-intrinsic": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.2",
-                "es-define-property": "^1.0.1",
-                "es-errors": "^1.3.0",
-                "es-object-atoms": "^1.1.1",
-                "function-bind": "^1.1.2",
-                "get-proto": "^1.0.1",
-                "gopd": "^1.2.0",
-                "has-symbols": "^1.1.0",
-                "hasown": "^2.0.2",
-                "math-intrinsics": "^1.1.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/get-package-type": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -4103,20 +3669,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8.0.0"
-            }
-        },
-        "node_modules/get-proto": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "dunder-proto": "^1.0.1",
-                "es-object-atoms": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
             }
         },
         "node_modules/get-stream": {
@@ -4154,32 +3706,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/glob-parent": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "is-glob": "^4.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/gopd": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/graceful-fs": {
             "version": "4.2.11",
             "dev": true,
@@ -4191,35 +3717,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/has-symbols": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-tostringtag": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-symbols": "^1.0.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/hasown": {
@@ -4379,27 +3876,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-expression": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
-            "integrity": "sha512-zMIXX63sxzG3XrkHkrAPvm/OVZVSCPNkwMHU8oTX7/U3AL78I0QXCEICXUM13BIa8TYGZ68PiTKfQz3yaTNr4A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "acorn": "^7.1.1",
-                "object-assign": "^4.1.1"
-            }
-        },
-        "node_modules/is-extglob": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
             "dev": true,
@@ -4418,33 +3894,10 @@
                 "node": ">=6"
             }
         },
-        "node_modules/is-glob": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-extglob": "^2.1.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/is-module": {
             "version": "1.0.0",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/is-number": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.12.0"
-            }
         },
         "node_modules/is-potential-custom-element-name": {
             "version": "1.0.1",
@@ -4452,32 +3905,6 @@
             "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/is-promise": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-            "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/is-regex": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
-            "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.2",
-                "gopd": "^1.2.0",
-                "has-tostringtag": "^1.0.2",
-                "hasown": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
         },
         "node_modules/is-stream": {
             "version": "2.0.1",
@@ -5211,13 +4638,6 @@
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
-        "node_modules/js-stringify": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
-            "integrity": "sha512-rtS5ATOo2Q5k1G+DADISilDA6lv79zIiwFd6CcjuIxGKLFm5C+RLImRscVap9k55i+MOZwgliw+NejvkLuGD5g==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "dev": true,
@@ -5238,46 +4658,25 @@
             }
         },
         "node_modules/jscpd": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/jscpd/-/jscpd-4.2.5.tgz",
-            "integrity": "sha512-KDpApYw1ChGelfHb7MwYTEx694OnW52pv3McAasidUV4ILcGDQMiVJzB+vI8ox+ZPVfOSvdXQCk8uRa9B0LXnw==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/jscpd/-/jscpd-5.0.9.tgz",
+            "integrity": "sha512-52zn0erBrRCCLvKulOs/UNUsL2fAmnMRUUbwbJhfUmqI9jtVSQ2Hk20F7m58JnkmgBEoyNBSTTomrF8K+H4fLA==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "@jscpd/badge-reporter": "4.2.5",
-                "@jscpd/core": "4.2.5",
-                "@jscpd/finder": "4.2.5",
-                "@jscpd/html-reporter": "4.2.5",
-                "@jscpd/tokenizer": "4.2.5",
-                "colors": "^1.4.0",
-                "commander": "^15.0.0",
-                "fs-extra": "^11.2.0",
-                "jscpd-sarif-reporter": "4.2.5"
-            },
             "bin": {
-                "jscpd": "bin/jscpd"
-            }
-        },
-        "node_modules/jscpd-sarif-reporter": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/jscpd-sarif-reporter/-/jscpd-sarif-reporter-4.2.5.tgz",
-            "integrity": "sha512-O8LcM9grAS5yO5x1Q0yegYaYcUX//IEBEyvzGFSYCeo1YzHbMnAI6EK7oTrwD+7Csjvfg9m8B8G7OOxzcSlr9w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "colors": "^1.4.0",
-                "fs-extra": "^11.2.0",
-                "node-sarif-builder": "^4.1.0"
-            }
-        },
-        "node_modules/jscpd/node_modules/commander": {
-            "version": "15.0.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
-            "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
-            "dev": true,
-            "license": "MIT",
+                "cpd": "run-jscpd.js",
+                "jscpd": "run-jscpd.js"
+            },
             "engines": {
-                "node": ">=22.12.0"
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "cpd-darwin-arm64": "5.0.9",
+                "cpd-darwin-x64": "5.0.9",
+                "cpd-linux-arm64-gnu": "5.0.9",
+                "cpd-linux-x64-gnu": "5.0.9",
+                "cpd-linux-x64-musl": "5.0.9",
+                "cpd-windows-x64-msvc": "5.0.9"
             }
         },
         "node_modules/jsdom": {
@@ -5351,30 +4750,6 @@
             },
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/jsonfile": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-            "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "universalify": "^2.0.0"
-            },
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/jstransformer": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-1.0.0.tgz",
-            "integrity": "sha512-C9YK3Rf8q6VAPDCCU9fnqo3mAfOH6vUGnMcP4AQAYIEpWtfGLpwOTmZ+igtdK5y+VvI2n3CyYSzy4Qh34eq24A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-promise": "^2.0.0",
-                "promise": "^7.0.1"
             }
         },
         "node_modules/leven": {
@@ -5469,71 +4844,10 @@
                 "tmpl": "1.0.5"
             }
         },
-        "node_modules/markdown-table": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
-            "integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "repeat-string": "^1.0.0"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/math-intrinsics": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/merge-stream": {
             "version": "2.0.0",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/merge2": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/micromatch": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "braces": "^3.0.3",
-                "picomatch": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=8.6"
-            }
-        },
-        "node_modules/micromatch/node_modules/picomatch": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
         },
         "node_modules/mimic-fn": {
             "version": "2.1.0",
@@ -5622,20 +4936,6 @@
                 "node": ">=18"
             }
         },
-        "node_modules/node-sarif-builder": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/node-sarif-builder/-/node-sarif-builder-4.1.0.tgz",
-            "integrity": "sha512-IWqZF6u0EI/07HTBm+zZ+MgXgWl09dnSJRGaDCPBSlOqilDcx6pj3Mpb3HvPN8V2Gr+ISw7ZrMsL7STWs1F++w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/sarif": "^2.1.7",
-                "fs-extra": "^11.1.1"
-            },
-            "engines": {
-                "node": ">=20"
-            }
-        },
         "node_modules/normalize-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -5663,16 +4963,6 @@
             "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/object-assign": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/once": {
             "version": "1.4.0",
@@ -5924,163 +5214,6 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
-        "node_modules/promise": {
-            "version": "7.3.1",
-            "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-            "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "asap": "~2.0.3"
-            }
-        },
-        "node_modules/pug": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/pug/-/pug-3.0.4.tgz",
-            "integrity": "sha512-kFfq5mMzrS7+wrl5pLJzZEzemx34OQ0w4SARfhy/3yxTlhbstsudDwJzhf1hP02yHzbjoVMSXUj/Sz6RNfMyXg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "pug-code-gen": "^3.0.4",
-                "pug-filters": "^4.0.0",
-                "pug-lexer": "^5.0.1",
-                "pug-linker": "^4.0.0",
-                "pug-load": "^3.0.0",
-                "pug-parser": "^6.0.0",
-                "pug-runtime": "^3.0.1",
-                "pug-strip-comments": "^2.0.0"
-            }
-        },
-        "node_modules/pug-attrs": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/pug-attrs/-/pug-attrs-3.0.0.tgz",
-            "integrity": "sha512-azINV9dUtzPMFQktvTXciNAfAuVh/L/JCl0vtPCwvOA21uZrC08K/UnmrL+SXGEVc1FwzjW62+xw5S/uaLj6cA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "constantinople": "^4.0.1",
-                "js-stringify": "^1.0.2",
-                "pug-runtime": "^3.0.0"
-            }
-        },
-        "node_modules/pug-code-gen": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.4.tgz",
-            "integrity": "sha512-6okWYIKdasTyXICyEtvobmTZAVX57JkzgzIi4iRJlin8kmhG+Xry2dsus+Mun/nGCn6F2U49haHI5mkELXB14g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "constantinople": "^4.0.1",
-                "doctypes": "^1.1.0",
-                "js-stringify": "^1.0.2",
-                "pug-attrs": "^3.0.0",
-                "pug-error": "^2.1.0",
-                "pug-runtime": "^3.0.1",
-                "void-elements": "^3.1.0",
-                "with": "^7.0.0"
-            }
-        },
-        "node_modules/pug-error": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-2.1.0.tgz",
-            "integrity": "sha512-lv7sU9e5Jk8IeUheHata6/UThZ7RK2jnaaNztxfPYUY+VxZyk/ePVaNZ/vwmH8WqGvDz3LrNYt/+gA55NDg6Pg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/pug-filters": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/pug-filters/-/pug-filters-4.0.0.tgz",
-            "integrity": "sha512-yeNFtq5Yxmfz0f9z2rMXGw/8/4i1cCFecw/Q7+D0V2DdtII5UvqE12VaZ2AY7ri6o5RNXiweGH79OCq+2RQU4A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "constantinople": "^4.0.1",
-                "jstransformer": "1.0.0",
-                "pug-error": "^2.0.0",
-                "pug-walk": "^2.0.0",
-                "resolve": "^1.15.1"
-            }
-        },
-        "node_modules/pug-lexer": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-5.0.1.tgz",
-            "integrity": "sha512-0I6C62+keXlZPZkOJeVam9aBLVP2EnbeDw3An+k0/QlqdwH6rv8284nko14Na7c0TtqtogfWXcRoFE4O4Ff20w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "character-parser": "^2.2.0",
-                "is-expression": "^4.0.0",
-                "pug-error": "^2.0.0"
-            }
-        },
-        "node_modules/pug-linker": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/pug-linker/-/pug-linker-4.0.0.tgz",
-            "integrity": "sha512-gjD1yzp0yxbQqnzBAdlhbgoJL5qIFJw78juN1NpTLt/mfPJ5VgC4BvkoD3G23qKzJtIIXBbcCt6FioLSFLOHdw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "pug-error": "^2.0.0",
-                "pug-walk": "^2.0.0"
-            }
-        },
-        "node_modules/pug-load": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/pug-load/-/pug-load-3.0.0.tgz",
-            "integrity": "sha512-OCjTEnhLWZBvS4zni/WUMjH2YSUosnsmjGBB1An7CsKQarYSWQ0GCVyd4eQPMFJqZ8w9xgs01QdiZXKVjk92EQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "object-assign": "^4.1.1",
-                "pug-walk": "^2.0.0"
-            }
-        },
-        "node_modules/pug-parser": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/pug-parser/-/pug-parser-6.0.0.tgz",
-            "integrity": "sha512-ukiYM/9cH6Cml+AOl5kETtM9NR3WulyVP2y4HOU45DyMim1IeP/OOiyEWRr6qk5I5klpsBnbuHpwKmTx6WURnw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "pug-error": "^2.0.0",
-                "token-stream": "1.0.0"
-            }
-        },
-        "node_modules/pug-runtime": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-3.0.1.tgz",
-            "integrity": "sha512-L50zbvrQ35TkpHwv0G6aLSuueDRwc/97XdY8kL3tOT0FmhgG7UypU3VztfV/LATAvmUfYi4wNxSajhSAeNN+Kg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/pug-strip-comments": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-2.0.0.tgz",
-            "integrity": "sha512-zo8DsDpH7eTkPHCXFeAk1xZXJbyoTfdPlNR0bK7rpOMuhBYb0f5qUVCO1xlsitYd3w5FQTK7zpNVKb3rZoUrrQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "pug-error": "^2.0.0"
-            }
-        },
-        "node_modules/pug-walk": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-2.0.0.tgz",
-            "integrity": "sha512-yYELe9Q5q9IQhuvqsZNwA5hfPkMJ8u92bQLIMcsMxf/VADjNtEYptU+inlufAFYcWdHlwNfZOEnOOQrZrcyJCQ==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/pump": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
-            "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-            }
-        },
         "node_modules/punycode": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -6108,27 +5241,6 @@
             ],
             "license": "MIT"
         },
-        "node_modules/queue-microtask": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
-        },
         "node_modules/react-is-18": {
             "name": "react-is",
             "version": "18.3.1",
@@ -6144,16 +5256,6 @@
             "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/repeat-string": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-            "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10"
-            }
         },
         "node_modules/require-directory": {
             "version": "2.1.1",
@@ -6208,21 +5310,10 @@
                 "node": ">=8"
             }
         },
-        "node_modules/reusify": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-            "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "iojs": ">=1.0.0",
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/rollup": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz",
-            "integrity": "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==",
+            "version": "4.61.0",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.0.tgz",
+            "integrity": "sha512-T9mWdbWfQtp0B5lv/HX+wrhYsmXRlcWnXXmJbXqKJhlRaoS6KMhq0gpyzW4UJfclcxrEdLnTgjT2NjruLONu0g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6236,31 +5327,31 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.61.1",
-                "@rollup/rollup-android-arm64": "4.61.1",
-                "@rollup/rollup-darwin-arm64": "4.61.1",
-                "@rollup/rollup-darwin-x64": "4.61.1",
-                "@rollup/rollup-freebsd-arm64": "4.61.1",
-                "@rollup/rollup-freebsd-x64": "4.61.1",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.61.1",
-                "@rollup/rollup-linux-arm-musleabihf": "4.61.1",
-                "@rollup/rollup-linux-arm64-gnu": "4.61.1",
-                "@rollup/rollup-linux-arm64-musl": "4.61.1",
-                "@rollup/rollup-linux-loong64-gnu": "4.61.1",
-                "@rollup/rollup-linux-loong64-musl": "4.61.1",
-                "@rollup/rollup-linux-ppc64-gnu": "4.61.1",
-                "@rollup/rollup-linux-ppc64-musl": "4.61.1",
-                "@rollup/rollup-linux-riscv64-gnu": "4.61.1",
-                "@rollup/rollup-linux-riscv64-musl": "4.61.1",
-                "@rollup/rollup-linux-s390x-gnu": "4.61.1",
-                "@rollup/rollup-linux-x64-gnu": "4.61.1",
-                "@rollup/rollup-linux-x64-musl": "4.61.1",
-                "@rollup/rollup-openbsd-x64": "4.61.1",
-                "@rollup/rollup-openharmony-arm64": "4.61.1",
-                "@rollup/rollup-win32-arm64-msvc": "4.61.1",
-                "@rollup/rollup-win32-ia32-msvc": "4.61.1",
-                "@rollup/rollup-win32-x64-gnu": "4.61.1",
-                "@rollup/rollup-win32-x64-msvc": "4.61.1",
+                "@rollup/rollup-android-arm-eabi": "4.61.0",
+                "@rollup/rollup-android-arm64": "4.61.0",
+                "@rollup/rollup-darwin-arm64": "4.61.0",
+                "@rollup/rollup-darwin-x64": "4.61.0",
+                "@rollup/rollup-freebsd-arm64": "4.61.0",
+                "@rollup/rollup-freebsd-x64": "4.61.0",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.61.0",
+                "@rollup/rollup-linux-arm-musleabihf": "4.61.0",
+                "@rollup/rollup-linux-arm64-gnu": "4.61.0",
+                "@rollup/rollup-linux-arm64-musl": "4.61.0",
+                "@rollup/rollup-linux-loong64-gnu": "4.61.0",
+                "@rollup/rollup-linux-loong64-musl": "4.61.0",
+                "@rollup/rollup-linux-ppc64-gnu": "4.61.0",
+                "@rollup/rollup-linux-ppc64-musl": "4.61.0",
+                "@rollup/rollup-linux-riscv64-gnu": "4.61.0",
+                "@rollup/rollup-linux-riscv64-musl": "4.61.0",
+                "@rollup/rollup-linux-s390x-gnu": "4.61.0",
+                "@rollup/rollup-linux-x64-gnu": "4.61.0",
+                "@rollup/rollup-linux-x64-musl": "4.61.0",
+                "@rollup/rollup-openbsd-x64": "4.61.0",
+                "@rollup/rollup-openharmony-arm64": "4.61.0",
+                "@rollup/rollup-win32-arm64-msvc": "4.61.0",
+                "@rollup/rollup-win32-ia32-msvc": "4.61.0",
+                "@rollup/rollup-win32-x64-gnu": "4.61.0",
+                "@rollup/rollup-win32-x64-msvc": "4.61.0",
                 "fsevents": "~2.3.2"
             }
         },
@@ -6291,30 +5382,6 @@
             "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/run-parallel": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "queue-microtask": "^1.2.2"
-            }
         },
         "node_modules/rw": {
             "version": "1.3.3",
@@ -6423,13 +5490,6 @@
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
             }
-        },
-        "node_modules/spark-md5": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz",
-            "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==",
-            "dev": true,
-            "license": "(WTFPL OR MIT)"
         },
         "node_modules/spdx-compare": {
             "version": "1.0.0",
@@ -6848,26 +5908,6 @@
             "dev": true,
             "license": "BSD-3-Clause"
         },
-        "node_modules/to-regex-range": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-number": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=8.0"
-            }
-        },
-        "node_modules/token-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
-            "integrity": "sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/tough-cookie": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
@@ -6939,16 +5979,6 @@
             "version": "7.19.2",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/universalify": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 10.0.0"
-            }
         },
         "node_modules/unrs-resolver": {
             "version": "1.12.2",
@@ -7034,16 +6064,6 @@
                 "node": ">=10.12.0"
             }
         },
-        "node_modules/void-elements": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
-            "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/w3c-xmlserializer": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
@@ -7127,22 +6147,6 @@
             },
             "engines": {
                 "node": ">= 8"
-            }
-        },
-        "node_modules/with": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/with/-/with-7.0.2.tgz",
-            "integrity": "sha512-RNGKj82nUPg3g5ygxkQl0R937xLyho1J24ItRCBTr/m1YnZkzJy1hUiHUJrc/VlsDQzsCnInEGSg3bci0Lmd4w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.9.6",
-                "@babel/types": "^7.9.6",
-                "assert-never": "^1.2.1",
-                "babel-walk": "3.0.0-canary-5"
-            },
-            "engines": {
-                "node": ">= 10.0.0"
             }
         },
         "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "d3-zoom": "^3.0",
         "jest": "^30.4",
         "jest-environment-jsdom": "^30.4",
-        "jscpd": "^4.2.5",
+        "jscpd": "^5.0.9",
         "rollup": "^4.61",
         "rollup-plugin-license": "^3.0",
         "typescript": "^6.0.3"


### PR DESCRIPTION
## Summary

jscpd 5 (a Rust rewrite) is the current major; this migrates the copy-paste-detection setup off the 4.x line. A config-only migration — no real clones surfaced.

- `.jscpd.json` to the 5.x schema: `languages`→`format`, `consoleFull`→`console-full`, `exitCode` `true`→`1`, trailing path slashes dropped.
- `ci:test:cpd` gains `--skip-comments` (jscpd 4 skipped comment tokens by default; v5 counts them, so the shared license/class docblock would register as a clone) and `--no-tips`.
- Bump jscpd to `^5.0.9` (5.0.6 restored reading the config's detection knobs that 5.0.4 ignored). The lockfile shrinks sharply because the v4 JS dep-tree is replaced by the v5 Rust binary.

## Verification
`composer ci:test` green — jscpd reports 0 clones, and the step still exits non-zero on a real duplicate.