### PR TITLE
Pin the Node toolchain to node:24-alpine (kill bundle-freshness phantom-diffs)

### DIFF
--- a/.github/workflows/bundle-freshness.yml
+++ b/.github/workflows/bundle-freshness.yml
@@ -12,3 +12,5 @@ jobs:
         uses: magicsunday/.github/.github/workflows/bundle-freshness.yml@main
         permissions:
             contents: read
+        with:
+            node-image: node:24-alpine

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
               name: Set up Node.js
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
-                  node-version: 22
+                  node-version: 24
                   cache: npm
 
             - id: setup_php

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -15,3 +15,4 @@ jobs:
             contents: read
         with:
             check-pipeline: true
+            node-image: node:24-alpine

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
     node:
-        image: node:lts-alpine
+        image: node:24-alpine
         working_dir: /app
         volumes:
             - ./:/app


### PR DESCRIPTION
Pin every Node entry point to `node:24-alpine` so the CI toolchain can no longer drift from the maintainer's local `make build` and produce bundle-freshness phantom-diffs.

Changes:
- `compose.yaml`: node service `node:lts-alpine` -> `node:24-alpine`
- `ci.yml`: setup-node `node-version: 22` -> `24`
- `bundle-freshness.yml` / `i18n.yml` callers: pass `node-image: node:24-alpine`

The committed bundle was rebuilt in `node:24-alpine` and is byte-identical (no `.min.js` change).

Part of magicsunday/.github#7.