### PR TITLE
GH-109: Add release-bootstrap + release-dry-run and verify the extracted dist zip

### DIFF
--- a/Make/release.mk
+++ b/Make/release.mk
@@ -10,6 +10,8 @@
 #   zip      — distribution archive creation + integrity check
 #   gh       — GitHub CLI for creating releases and pushing tags
 #   sed      — text substitution for PHP version string (Module.php)
+#   unzip    — extract the dist zip to verify its contents (dist-smoke)
+#   php      — lint the extracted module.php (php -l) in dist-smoke
 #
 # Non-interactive use:
 #   export GH_TOKEN=<token>   # instead of 'gh auth login'
@@ -43,15 +45,39 @@ SCOPE_NS         := PedigreeChartVendor
 # Accept both 'make release 3.1.0' (goal form) and 'make release VERSION=3.1.0'.
 VERSION ?= $(filter-out release release-% dist,$(MAKECMDGOALS))
 
-REQUIRED_TOOLS := git node npm composer jq zip gh sed
+REQUIRED_TOOLS := git node npm composer jq zip unzip gh sed php
 
 .PHONY: release release-check release-prepare release-publish release-bump \
-        release-recover dist dist-smoke clean-js release-clean build-js-fresh
+        release-recover dist dist-smoke clean-js release-clean build-js-fresh \
+        release-bootstrap release-dry-run
 
 # release pipeline operates on shared repo state — must run sequentially.
 .NOTPARALLEL:
 
-## Verify all required tools, VERSION, clean tree, no active link-base symlink, gh auth.
+## Provision the dev toolchain a release needs but that a fresh checkout or a
+## prior 'make dist' (composer update --no-dev wipes .build/vendor's dev tools)
+## may have left missing — so 'make release' / 'make release-dry-run' run end to
+## end without a manual 'composer install' / 'npm ci' first. Idempotent: each
+## step is guarded and skips when already present, so it is cheap on a warm tree.
+##   1. .build/vendor dev tools (phpstan/php-cs-fixer/phpunit) for 'composer ci:test'
+##   2. node_modules with the built chart-lib dist (the github source dep ships no
+##      dist/; only a real 'npm ci' clones + builds it) for the rollup + js:typecheck
+release-bootstrap:
+	@if [ ! -d $(VENDOR_DIR)/phpstan/phpstan ]; then \
+		echo -e "${FYELLOW}[bootstrap]${FRESET} Restoring dev toolchain ($(VENDOR_DIR))..."; \
+		composer install --no-interaction --no-progress; \
+	fi
+	@if [ ! -f node_modules/@magicsunday/webtrees-chart-lib/dist/webtrees-chart-lib.es.js ]; then \
+		echo -e "${FYELLOW}[bootstrap]${FRESET} Installing node deps + building chart-lib dist (npm ci)..."; \
+		npm ci; \
+	fi
+	@echo -e "${FGREEN} ✔${FRESET} Release toolchain ready"
+
+## Verify all required tools, VERSION, clean tree, no active link-base / link-chart-lib
+## symlink, node_modules ownership, gh auth — THEN provision the toolchain. Bootstrap
+## runs LAST (from the recipe, not as a prerequisite) so its composer install / npm ci
+## can never clobber an active link-base / link-chart-lib BEFORE the symlink guards below
+## reject it.
 release-check:
 	@missing=""; \
 	for tool in $(REQUIRED_TOOLS); do \
@@ -94,10 +120,17 @@ release-check:
 		echo "would ship as a broken absolute symlink inside the release zip."; \
 		exit 1; \
 	fi
-	@if [ -d node_modules ] && [ -n "$$(find node_modules ! -uid $$(id -u) -print -quit 2>/dev/null)" ]; then \
+	@if [ -L node_modules/@magicsunday/webtrees-chart-lib ]; then \
+		echo "Error: node_modules/@magicsunday/webtrees-chart-lib is a symlink (active 'make link-chart-lib')."; \
+		echo "Run 'make unlink-chart-lib' before releasing — the rollup build would"; \
+		echo "bundle the sibling clone instead of the tagged release."; \
+		exit 1; \
+	fi
+	@if [ -d node_modules ] && [ -n "$$(find node_modules ! -uid $$(id -u) -print 2>/dev/null | head -n 1)" ]; then \
 		echo "Error: node_modules contains files not owned by the current user."; \
-		echo "Files left by a container run as root cannot be removed by the release"; \
-		echo "build and would abort build-js-fresh mid-way. Clear them as root first:"; \
+		echo "A prior 'make unlink-chart-lib' run from the host (root in the compose"; \
+		echo "container) can leave root-owned files that the release build cannot"; \
+		echo "remove, aborting build-js-fresh mid-way. Clear them as root first:"; \
 		echo "  docker run --rm -v \"\$$PWD\":/m alpine rm -rf /m/node_modules"; \
 		exit 1; \
 	fi
@@ -107,6 +140,7 @@ release-check:
 		exit 1; \
 	fi
 	@echo -e "${FGREEN} ✔${FRESET} Release checks passed for $(VERSION)"
+	@$(MAKE) release-bootstrap
 
 ## Remove old versioned JS bundles before building new ones (filesystem + git)
 clean-js:
@@ -188,6 +222,7 @@ dist-smoke:
 	done; \
 	for prefix in \
 		resources/js/$(JS_NAME)-[0-9] \
+		vendor/magicsunday/webtrees-module-base/src/Contract/ \
 		vendor/magicsunday/webtrees-module-base/src/Model/ \
 		vendor/magicsunday/webtrees-module-base/src/Module/ \
 		vendor/magicsunday/webtrees-module-base/src/Processor/ \
@@ -206,7 +241,24 @@ dist-smoke:
 		echo "Error: module.php in zip still contains unprefixed MagicSunday\\Webtrees\\ModuleBase"; \
 		exit 1; \
 	fi
-	@echo -e "${FGREEN} ✔${FRESET} dist-smoke passed: $(MODULE_NAME).zip is well-formed"
+	# Beyond the entry-list checks above: actually EXTRACT the zip and verify the
+	# unpacked tree — module.php parses, key files are non-empty, the versioned JS
+	# bundle is present and non-empty, and every bundled module-base src/ dir holds
+	# real PHP files (a truncated/empty bundle or a missing namespace dir passes a
+	# name-only listing but fails here).
+	@tmp=$$(mktemp -d); trap '[ -n "$$tmp" ] && rm -rf "$$tmp"' EXIT; \
+	unzip -q $(MODULE_NAME).zip -d "$$tmp" || { echo "Error: $(MODULE_NAME).zip failed to extract"; exit 1; }; \
+	for f in module.php LICENSE; do \
+		[ -s "$$tmp/$$f" ] || { echo "Error: $$f missing or empty in extracted zip"; exit 1; }; \
+	done; \
+	php -l "$$tmp/module.php" >/dev/null 2>&1 || { echo "Error: extracted module.php does not parse"; exit 1; }; \
+	bundle=$$(ls "$$tmp"/resources/js/$(JS_NAME)-[0-9]*.min.js 2>/dev/null | head -1); \
+	[ -s "$$bundle" ] || { echo "Error: versioned JS bundle missing or empty in extracted resources/js/"; exit 1; }; \
+	for d in Contract Model Module Processor; do \
+		find "$$tmp/vendor/magicsunday/webtrees-module-base/src/$$d" -name '*.php' -print 2>/dev/null | grep -q . \
+			|| { echo "Error: bundled module-base src/$$d has no PHP files in extracted zip"; exit 1; }; \
+	done
+	@echo -e "${FGREEN} ✔${FRESET} dist-smoke passed: $(MODULE_NAME).zip extracts to a well-formed module"
 
 # Atomic JSON edit with cleanup on failure + post-write assertion. Usage:
 #   $(call jq_edit,FILE,WRITE_EXPR,ARGS,VERIFY_EXPR)
@@ -371,6 +423,72 @@ release-recover:
 		echo "  git reset --soft HEAD~1"; \
 	fi
 	@echo "If a tag was created, remove it with: git tag -d <VERSION>"
+
+## Dry run — rehearse the whole build pipeline WITHOUT committing, tagging,
+## pushing or publishing, then restore the working tree. Validates exactly the
+## steps that historically broke a release (toolchain provisioning, the full
+## ci:test gate, the clean-room rollup build incl. chart-lib dist, the dist zip
+## and its smoke test). No VERSION, gh auth or network needed.
+##   make release-dry-run
+# No release-bootstrap PREREQUISITE: the guards below must abort BEFORE any
+# provisioning work, so a dirty tree / active symlink fails fast. Bootstrap is
+# invoked from the recipe once the guards have passed.
+release-dry-run:
+	@echo -e "${FYELLOW}[dry-run]${FRESET} Release rehearsal — NO commit, tag, push or publish."
+	# Guard like release-check (minus VERSION/gh): the rehearsal rebuilds and then
+	# REVERTS the JS bundle, and build-js-fresh wipes node_modules — so on a dirty
+	# tree it would discard uncommitted work, and an active link-base / link-chart-lib
+	# symlink would be destroyed. Refuse to run unless the tree is clean + unlinked.
+	@if [ -n "$$(git status --porcelain --untracked-files=no)" ]; then \
+		echo "Error: working tree not clean — commit or stash first (the dry run rebuilds and then reverts the JS bundle)."; \
+		exit 1; \
+	fi
+	@if [ -L $(MODULE_BASE_PATH) ]; then \
+		echo "Error: $(MODULE_BASE_PATH) is a symlink (active 'make link-base'). Run 'make unlink-base' first."; \
+		exit 1; \
+	fi
+	@if [ -L node_modules/@magicsunday/webtrees-chart-lib ]; then \
+		echo "Error: node_modules/@magicsunday/webtrees-chart-lib is a symlink (active 'make link-chart-lib'); build-js-fresh would destroy it. Run 'make unlink-chart-lib' first."; \
+		exit 1; \
+	fi
+	@if [ -d node_modules ] && [ -n "$$(find node_modules ! -uid $$(id -u) -print 2>/dev/null | head -n 1)" ]; then \
+		echo "Error: node_modules contains files not owned by the current user."; \
+		echo "A prior 'make unlink-chart-lib' run from the host (root in the compose"; \
+		echo "container) can leave root-owned files that build-js-fresh's 'rm -rf"; \
+		echo "node_modules' cannot remove, aborting the dry run mid-way. Clear them"; \
+		echo "as root first:  docker run --rm -v \"\$$PWD\":/m alpine rm -rf /m/node_modules"; \
+		exit 1; \
+	fi
+	@$(MAKE) release-bootstrap
+	# Run the rehearsal capturing its own status, then ALWAYS restore the tree, and
+	# exit with the rehearsal's status. A cleanup failure must not mask a failed run
+	# (nor a passing run a failed cleanup), and the closing message must tell the
+	# truth. `.build/vendor` is left at --no-dev by `dist`; the next release-bootstrap
+	# re-provisions it on demand.
+	@rc=0; { \
+		echo -e "${FYELLOW}[dry-run 1/4]${FRESET} Running the full CI test suite..." && \
+		npm ci && \
+		composer ci:test && \
+		echo -e "${FYELLOW}[dry-run 2/4]${FRESET} Clean-room JavaScript build..." && \
+		$(MAKE) build-js-fresh && \
+		echo -e "${FYELLOW}[dry-run 3/4]${FRESET} Building distribution archive..." && \
+		$(MAKE) dist && \
+		echo -e "${FYELLOW}[dry-run 4/4]${FRESET} Smoke-testing the archive..." && \
+		$(MAKE) dist-smoke; \
+	} || rc=$$?; \
+	$(MAKE) release-recover || true; \
+	dirty=$$(git status --porcelain --untracked-files=no); \
+	if [ "$$rc" -ne 0 ]; then \
+		echo -e "${FRED} ✘${FRESET} Dry run FAILED (rc=$$rc) — attempted to restore the working tree."; \
+		if [ -n "$$dirty" ]; then echo "   note: tracked files still differ — run 'make release-recover'."; fi; \
+		exit $$rc; \
+	elif [ -n "$$dirty" ]; then \
+		echo -e "${FRED} ✘${FRESET} Rehearsal passed but the working tree is NOT clean after restore — run 'make release-recover':"; \
+		git status --short; \
+		exit 1; \
+	else \
+		echo -e "${FGREEN} ✔ Dry run complete — the release would succeed. Working tree restored.${FRESET}"; \
+	fi
 
 ## Full release pipeline
 release: release-prepare release-publish release-bump release-clean ## Create and publish a release (usage: make release 3.1.0)


### PR DESCRIPTION
Closes #109.

Ports the release-tooling improvements already shipped in `webtrees-statistics` (mirrors statistics PRs 205/207) to this module's `Make/release.mk`. After this change the file is byte-identical to the statistics reference apart from `MODULE_NAME` / `SCOPE_NS` and cosmetic version examples.

## Changes

- **`release-bootstrap` target** — idempotently provisions the dev toolchain a release needs (`.build/vendor` dev tools for `composer ci:test`; `node_modules` with the built chart-lib dist for the rollup build), so `make release` / `make release-dry-run` run end to end without a manual `composer install` / `npm ci` first. Invoked from the `release-check` recipe as the LAST line (never as a prerequisite), so it cannot clobber an active `link-base` / `link-chart-lib` symlink before the guards reject it.
- **`release-dry-run` target** — rehearses the whole build pipeline (toolchain provisioning, full `ci:test`, clean-room rollup build, dist zip + smoke test) WITHOUT committing, tagging, pushing or publishing, then restores the working tree, capturing the rehearsal rc, always restoring, and reporting a non-clean tree truthfully.
- **`dist-smoke` extraction pass** — beyond the name-only entry-list checks, actually EXTRACTS the zip and verifies the unpacked tree: `module.php` parses (`php -l`), key files are non-empty, the versioned JS bundle is present and non-empty, and every bundled module-base `src/` dir (`Contract` / `Model` / `Module` / `Processor`) holds real PHP files. Catches a truncated/empty bundle or a missing namespace dir that a name-only listing would pass.
- Adds the `link-chart-lib` symlink guard and aligns the `node_modules` ownership guard (`find ... | head -n 1`) with statistics.
- `REQUIRED_TOOLS` and the `# Requires:` doc block gain `unzip` + `php` (needed by the new dist-smoke extraction).

## Verification

`make dist && make dist-smoke` in the buildbox:

```
 ✔ dist-smoke passed: webtrees-pedigree-chart.zip extracts to a well-formed module
```