### PR TITLE
GH-118: Forward the display settings through the re-centering URL

### DIFF
--- a/resources/lang/cs/messages.po
+++ b/resources/lang/cs/messages.po
@@ -22,11 +22,11 @@ msgstr ""
 msgid "A pedigree chart of an individual’s ancestors."
 msgstr "Přehled předků osoby."
 
-#: src/Configuration.php:414
+#: src/Configuration.php:421
 msgid "Abbreviate given names first"
 msgstr "Nejprve zkrátit křestní jména"
 
-#: src/Configuration.php:415
+#: src/Configuration.php:422
 msgid "Abbreviate surnames first"
 msgstr "Nejprve zkrátit příjmení"
 
@@ -38,7 +38,7 @@ msgstr ""
 msgid "Add a mother"
 msgstr ""
 
-#: src/Configuration.php:413
+#: src/Configuration.php:420
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automaticky (podle tradice příjmení stromu)"
 
@@ -225,15 +225,15 @@ msgstr ""
 msgid "cancel"
 msgstr "zrušit"
 
-#: src/Configuration.php:178 src/Configuration.php:186
+#: src/Configuration.php:185 src/Configuration.php:193
 msgid "down"
 msgstr "dolů"
 
-#: src/Configuration.php:175 src/Configuration.php:183
+#: src/Configuration.php:182 src/Configuration.php:190
 msgid "left"
 msgstr "vlevo"
 
-#: src/Configuration.php:176 src/Configuration.php:184
+#: src/Configuration.php:183 src/Configuration.php:191
 msgid "right"
 msgstr "vpravo"
 
@@ -241,7 +241,7 @@ msgstr "vpravo"
 msgid "save"
 msgstr "uložit"
 
-#: src/Configuration.php:177 src/Configuration.php:185
+#: src/Configuration.php:184 src/Configuration.php:192
 msgid "up"
 msgstr "nahoru"
 

--- a/resources/lang/da/messages.po
+++ b/resources/lang/da/messages.po
@@ -22,11 +22,11 @@ msgstr ""
 msgid "A pedigree chart of an individual’s ancestors."
 msgstr "En stamtavle over en persons forfædre."
 
-#: src/Configuration.php:414
+#: src/Configuration.php:421
 msgid "Abbreviate given names first"
 msgstr "Forkort fornavne først"
 
-#: src/Configuration.php:415
+#: src/Configuration.php:422
 msgid "Abbreviate surnames first"
 msgstr "Forkort efternavne først"
 
@@ -38,7 +38,7 @@ msgstr ""
 msgid "Add a mother"
 msgstr ""
 
-#: src/Configuration.php:413
+#: src/Configuration.php:420
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisk (baseret på træets efternavnstradition)"
 
@@ -225,15 +225,15 @@ msgstr ""
 msgid "cancel"
 msgstr "fortryd"
 
-#: src/Configuration.php:178 src/Configuration.php:186
+#: src/Configuration.php:185 src/Configuration.php:193
 msgid "down"
 msgstr "ned"
 
-#: src/Configuration.php:175 src/Configuration.php:183
+#: src/Configuration.php:182 src/Configuration.php:190
 msgid "left"
 msgstr "venstre"
 
-#: src/Configuration.php:176 src/Configuration.php:184
+#: src/Configuration.php:183 src/Configuration.php:191
 msgid "right"
 msgstr "højre"
 
@@ -241,7 +241,7 @@ msgstr "højre"
 msgid "save"
 msgstr "gem"
 
-#: src/Configuration.php:177 src/Configuration.php:185
+#: src/Configuration.php:184 src/Configuration.php:192
 msgid "up"
 msgstr "op"
 

--- a/resources/lang/de/messages.po
+++ b/resources/lang/de/messages.po
@@ -22,11 +22,11 @@ msgstr ""
 msgid "A pedigree chart of an individual’s ancestors."
 msgstr "Ein Stammbaum der Vorfahren einer Person."
 
-#: src/Configuration.php:414
+#: src/Configuration.php:421
 msgid "Abbreviate given names first"
 msgstr "Zuerst Vornamen abkürzen"
 
-#: src/Configuration.php:415
+#: src/Configuration.php:422
 msgid "Abbreviate surnames first"
 msgstr "Zuerst Nachnamen abkürzen"
 
@@ -38,7 +38,7 @@ msgstr ""
 msgid "Add a mother"
 msgstr ""
 
-#: src/Configuration.php:413
+#: src/Configuration.php:420
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisch (basierend auf der Nachnamen-Tradition des Stammbaums)"
 
@@ -233,15 +233,15 @@ msgstr ""
 msgid "cancel"
 msgstr "Abbrechen"
 
-#: src/Configuration.php:178 src/Configuration.php:186
+#: src/Configuration.php:185 src/Configuration.php:193
 msgid "down"
 msgstr "Unten"
 
-#: src/Configuration.php:175 src/Configuration.php:183
+#: src/Configuration.php:182 src/Configuration.php:190
 msgid "left"
 msgstr "Links"
 
-#: src/Configuration.php:176 src/Configuration.php:184
+#: src/Configuration.php:183 src/Configuration.php:191
 msgid "right"
 msgstr "Rechts"
 
@@ -249,7 +249,7 @@ msgstr "Rechts"
 msgid "save"
 msgstr "Speichern"
 
-#: src/Configuration.php:177 src/Configuration.php:185
+#: src/Configuration.php:184 src/Configuration.php:192
 msgid "up"
 msgstr "Oben"
 

--- a/resources/lang/en-GB/messages.po
+++ b/resources/lang/en-GB/messages.po
@@ -22,11 +22,11 @@ msgstr ""
 msgid "A pedigree chart of an individual’s ancestors."
 msgstr "A pedigree chart of an individual’s ancestors."
 
-#: src/Configuration.php:414
+#: src/Configuration.php:421
 msgid "Abbreviate given names first"
 msgstr "Abbreviate given names first"
 
-#: src/Configuration.php:415
+#: src/Configuration.php:422
 msgid "Abbreviate surnames first"
 msgstr "Abbreviate surnames first"
 
@@ -38,7 +38,7 @@ msgstr ""
 msgid "Add a mother"
 msgstr ""
 
-#: src/Configuration.php:413
+#: src/Configuration.php:420
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatic (based on tree's surname tradition)"
 
@@ -225,15 +225,15 @@ msgstr ""
 msgid "cancel"
 msgstr "cancel"
 
-#: src/Configuration.php:178 src/Configuration.php:186
+#: src/Configuration.php:185 src/Configuration.php:193
 msgid "down"
 msgstr "down"
 
-#: src/Configuration.php:175 src/Configuration.php:183
+#: src/Configuration.php:182 src/Configuration.php:190
 msgid "left"
 msgstr "left"
 
-#: src/Configuration.php:176 src/Configuration.php:184
+#: src/Configuration.php:183 src/Configuration.php:191
 msgid "right"
 msgstr "right"
 
@@ -241,7 +241,7 @@ msgstr "right"
 msgid "save"
 msgstr "save"
 
-#: src/Configuration.php:177 src/Configuration.php:185
+#: src/Configuration.php:184 src/Configuration.php:192
 msgid "up"
 msgstr "up"
 

--- a/resources/lang/en-US/messages.po
+++ b/resources/lang/en-US/messages.po
@@ -23,11 +23,11 @@ msgstr ""
 msgid "A pedigree chart of an individual’s ancestors."
 msgstr "A pedigree chart of an individual’s ancestors."
 
-#: src/Configuration.php:414
+#: src/Configuration.php:421
 msgid "Abbreviate given names first"
 msgstr "Abbreviate given names first"
 
-#: src/Configuration.php:415
+#: src/Configuration.php:422
 msgid "Abbreviate surnames first"
 msgstr "Abbreviate surnames first"
 
@@ -39,7 +39,7 @@ msgstr ""
 msgid "Add a mother"
 msgstr ""
 
-#: src/Configuration.php:413
+#: src/Configuration.php:420
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatic (based on tree's surname tradition)"
 
@@ -226,15 +226,15 @@ msgstr ""
 msgid "cancel"
 msgstr "cancel"
 
-#: src/Configuration.php:178 src/Configuration.php:186
+#: src/Configuration.php:185 src/Configuration.php:193
 msgid "down"
 msgstr "down"
 
-#: src/Configuration.php:175 src/Configuration.php:183
+#: src/Configuration.php:182 src/Configuration.php:190
 msgid "left"
 msgstr "left"
 
-#: src/Configuration.php:176 src/Configuration.php:184
+#: src/Configuration.php:183 src/Configuration.php:191
 msgid "right"
 msgstr "right"
 
@@ -242,7 +242,7 @@ msgstr "right"
 msgid "save"
 msgstr "save"
 
-#: src/Configuration.php:177 src/Configuration.php:185
+#: src/Configuration.php:184 src/Configuration.php:192
 msgid "up"
 msgstr "up"
 

--- a/resources/lang/es/messages.po
+++ b/resources/lang/es/messages.po
@@ -22,11 +22,11 @@ msgstr ""
 msgid "A pedigree chart of an individual’s ancestors."
 msgstr "Un árbol de pedigrí de los antepasados de un individuo."
 
-#: src/Configuration.php:414
+#: src/Configuration.php:421
 msgid "Abbreviate given names first"
 msgstr "Abreviar primero los nombres de pila"
 
-#: src/Configuration.php:415
+#: src/Configuration.php:422
 msgid "Abbreviate surnames first"
 msgstr "Abreviar primero los apellidos"
 
@@ -38,7 +38,7 @@ msgstr ""
 msgid "Add a mother"
 msgstr ""
 
-#: src/Configuration.php:413
+#: src/Configuration.php:420
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automático (según la tradición de apellidos del árbol)"
 
@@ -228,15 +228,15 @@ msgstr ""
 msgid "cancel"
 msgstr "Cancelar"
 
-#: src/Configuration.php:178 src/Configuration.php:186
+#: src/Configuration.php:185 src/Configuration.php:193
 msgid "down"
 msgstr "abajo"
 
-#: src/Configuration.php:175 src/Configuration.php:183
+#: src/Configuration.php:182 src/Configuration.php:190
 msgid "left"
 msgstr "izquierda"
 
-#: src/Configuration.php:176 src/Configuration.php:184
+#: src/Configuration.php:183 src/Configuration.php:191
 msgid "right"
 msgstr "derecha"
 
@@ -244,7 +244,7 @@ msgstr "derecha"
 msgid "save"
 msgstr "guardar"
 
-#: src/Configuration.php:177 src/Configuration.php:185
+#: src/Configuration.php:184 src/Configuration.php:192
 msgid "up"
 msgstr "arriba"
 

--- a/resources/lang/fr/messages.po
+++ b/resources/lang/fr/messages.po
@@ -22,11 +22,11 @@ msgstr ""
 msgid "A pedigree chart of an individual’s ancestors."
 msgstr "Un arbre généalogique des ancêtres d'un individu."
 
-#: src/Configuration.php:414
+#: src/Configuration.php:421
 msgid "Abbreviate given names first"
 msgstr "Abréger d'abord les prénoms"
 
-#: src/Configuration.php:415
+#: src/Configuration.php:422
 msgid "Abbreviate surnames first"
 msgstr "Abréger d'abord les noms de famille"
 
@@ -38,7 +38,7 @@ msgstr ""
 msgid "Add a mother"
 msgstr ""
 
-#: src/Configuration.php:413
+#: src/Configuration.php:420
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatique (selon la tradition des noms de famille de l'arbre)"
 
@@ -229,15 +229,15 @@ msgstr ""
 msgid "cancel"
 msgstr "annuler"
 
-#: src/Configuration.php:178 src/Configuration.php:186
+#: src/Configuration.php:185 src/Configuration.php:193
 msgid "down"
 msgstr "bas"
 
-#: src/Configuration.php:175 src/Configuration.php:183
+#: src/Configuration.php:182 src/Configuration.php:190
 msgid "left"
 msgstr "gauche"
 
-#: src/Configuration.php:176 src/Configuration.php:184
+#: src/Configuration.php:183 src/Configuration.php:191
 msgid "right"
 msgstr "droite"
 
@@ -245,7 +245,7 @@ msgstr "droite"
 msgid "save"
 msgstr "enregistrer"
 
-#: src/Configuration.php:177 src/Configuration.php:185
+#: src/Configuration.php:184 src/Configuration.php:192
 msgid "up"
 msgstr "haut"
 

--- a/resources/lang/is/messages.po
+++ b/resources/lang/is/messages.po
@@ -22,11 +22,11 @@ msgstr ""
 msgid "A pedigree chart of an individual’s ancestors."
 msgstr "Ættartafla yfir forfeður einstaklings."
 
-#: src/Configuration.php:414
+#: src/Configuration.php:421
 msgid "Abbreviate given names first"
 msgstr "Stytta eiginnöfn fyrst"
 
-#: src/Configuration.php:415
+#: src/Configuration.php:422
 msgid "Abbreviate surnames first"
 msgstr "Stytta eftirnöfn fyrst"
 
@@ -38,7 +38,7 @@ msgstr ""
 msgid "Add a mother"
 msgstr ""
 
-#: src/Configuration.php:413
+#: src/Configuration.php:420
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Sjálfvirkt (byggt á eftirnafnshefð trésins)"
 
@@ -229,15 +229,15 @@ msgstr ""
 msgid "cancel"
 msgstr "hætta"
 
-#: src/Configuration.php:178 src/Configuration.php:186
+#: src/Configuration.php:185 src/Configuration.php:193
 msgid "down"
 msgstr "niður"
 
-#: src/Configuration.php:175 src/Configuration.php:183
+#: src/Configuration.php:182 src/Configuration.php:190
 msgid "left"
 msgstr "vinstri"
 
-#: src/Configuration.php:176 src/Configuration.php:184
+#: src/Configuration.php:183 src/Configuration.php:191
 msgid "right"
 msgstr "hægri"
 
@@ -245,7 +245,7 @@ msgstr "hægri"
 msgid "save"
 msgstr "vista"
 
-#: src/Configuration.php:177 src/Configuration.php:185
+#: src/Configuration.php:184 src/Configuration.php:192
 msgid "up"
 msgstr "upp"
 

--- a/resources/lang/nb/messages.po
+++ b/resources/lang/nb/messages.po
@@ -22,11 +22,11 @@ msgstr ""
 msgid "A pedigree chart of an individual’s ancestors."
 msgstr "Et diagram over en persons aner."
 
-#: src/Configuration.php:414
+#: src/Configuration.php:421
 msgid "Abbreviate given names first"
 msgstr "Forkort fornavn først"
 
-#: src/Configuration.php:415
+#: src/Configuration.php:422
 msgid "Abbreviate surnames first"
 msgstr "Forkort etternavn først"
 
@@ -38,7 +38,7 @@ msgstr ""
 msgid "Add a mother"
 msgstr ""
 
-#: src/Configuration.php:413
+#: src/Configuration.php:420
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisk (basert på treets etternavnstradisjon)"
 
@@ -229,15 +229,15 @@ msgstr ""
 msgid "cancel"
 msgstr "avbryt"
 
-#: src/Configuration.php:178 src/Configuration.php:186
+#: src/Configuration.php:185 src/Configuration.php:193
 msgid "down"
 msgstr "ned"
 
-#: src/Configuration.php:175 src/Configuration.php:183
+#: src/Configuration.php:182 src/Configuration.php:190
 msgid "left"
 msgstr "venstre"
 
-#: src/Configuration.php:176 src/Configuration.php:184
+#: src/Configuration.php:183 src/Configuration.php:191
 msgid "right"
 msgstr "høyre"
 
@@ -245,7 +245,7 @@ msgstr "høyre"
 msgid "save"
 msgstr "lagre"
 
-#: src/Configuration.php:177 src/Configuration.php:185
+#: src/Configuration.php:184 src/Configuration.php:192
 msgid "up"
 msgstr "opp"
 

--- a/resources/lang/nl/messages.po
+++ b/resources/lang/nl/messages.po
@@ -22,11 +22,11 @@ msgstr ""
 msgid "A pedigree chart of an individual’s ancestors."
 msgstr "Een kwartierstaat van de voorouders van een persoon."
 
-#: src/Configuration.php:414
+#: src/Configuration.php:421
 msgid "Abbreviate given names first"
 msgstr "Voornamen eerst afkorten"
 
-#: src/Configuration.php:415
+#: src/Configuration.php:422
 msgid "Abbreviate surnames first"
 msgstr "Achternamen eerst afkorten"
 
@@ -38,7 +38,7 @@ msgstr ""
 msgid "Add a mother"
 msgstr ""
 
-#: src/Configuration.php:413
+#: src/Configuration.php:420
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisch (op basis van de achternaamtraditie van de stamboom)"
 
@@ -233,15 +233,15 @@ msgstr ""
 msgid "cancel"
 msgstr "annuleren"
 
-#: src/Configuration.php:178 src/Configuration.php:186
+#: src/Configuration.php:185 src/Configuration.php:193
 msgid "down"
 msgstr "omlaag"
 
-#: src/Configuration.php:175 src/Configuration.php:183
+#: src/Configuration.php:182 src/Configuration.php:190
 msgid "left"
 msgstr "links"
 
-#: src/Configuration.php:176 src/Configuration.php:184
+#: src/Configuration.php:183 src/Configuration.php:191
 msgid "right"
 msgstr "rechts"
 
@@ -249,7 +249,7 @@ msgstr "rechts"
 msgid "save"
 msgstr "opslaan"
 
-#: src/Configuration.php:177 src/Configuration.php:185
+#: src/Configuration.php:184 src/Configuration.php:192
 msgid "up"
 msgstr "omhoog"
 

--- a/resources/lang/nn/messages.po
+++ b/resources/lang/nn/messages.po
@@ -22,11 +22,11 @@ msgstr ""
 msgid "A pedigree chart of an individual’s ancestors."
 msgstr "Eit diagram over ein person sine anar."
 
-#: src/Configuration.php:414
+#: src/Configuration.php:421
 msgid "Abbreviate given names first"
 msgstr "Forkort førenamn først"
 
-#: src/Configuration.php:415
+#: src/Configuration.php:422
 msgid "Abbreviate surnames first"
 msgstr "Forkort etternamn først"
 
@@ -38,7 +38,7 @@ msgstr ""
 msgid "Add a mother"
 msgstr ""
 
-#: src/Configuration.php:413
+#: src/Configuration.php:420
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisk (basert på etternamnstradisjonen til treet)"
 
@@ -230,15 +230,15 @@ msgstr ""
 msgid "cancel"
 msgstr "avbryt"
 
-#: src/Configuration.php:178 src/Configuration.php:186
+#: src/Configuration.php:185 src/Configuration.php:193
 msgid "down"
 msgstr "ned"
 
-#: src/Configuration.php:175 src/Configuration.php:183
+#: src/Configuration.php:182 src/Configuration.php:190
 msgid "left"
 msgstr "venstre"
 
-#: src/Configuration.php:176 src/Configuration.php:184
+#: src/Configuration.php:183 src/Configuration.php:191
 msgid "right"
 msgstr "høgre"
 
@@ -246,7 +246,7 @@ msgstr "høgre"
 msgid "save"
 msgstr "lagre"
 
-#: src/Configuration.php:177 src/Configuration.php:185
+#: src/Configuration.php:184 src/Configuration.php:192
 msgid "up"
 msgstr "opp"
 

--- a/resources/lang/ru/messages.po
+++ b/resources/lang/ru/messages.po
@@ -23,11 +23,11 @@ msgstr ""
 msgid "A pedigree chart of an individual’s ancestors."
 msgstr "Родословная карта предков в виде дерева."
 
-#: src/Configuration.php:414
+#: src/Configuration.php:421
 msgid "Abbreviate given names first"
 msgstr "Сокращать сначала имена"
 
-#: src/Configuration.php:415
+#: src/Configuration.php:422
 msgid "Abbreviate surnames first"
 msgstr "Сокращать сначала фамилии"
 
@@ -39,7 +39,7 @@ msgstr ""
 msgid "Add a mother"
 msgstr ""
 
-#: src/Configuration.php:413
+#: src/Configuration.php:420
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Автоматически (по традиции фамилий дерева)"
 
@@ -226,15 +226,15 @@ msgstr ""
 msgid "cancel"
 msgstr "Отмена"
 
-#: src/Configuration.php:178 src/Configuration.php:186
+#: src/Configuration.php:185 src/Configuration.php:193
 msgid "down"
 msgstr "вниз"
 
-#: src/Configuration.php:175 src/Configuration.php:183
+#: src/Configuration.php:182 src/Configuration.php:190
 msgid "left"
 msgstr "влево"
 
-#: src/Configuration.php:176 src/Configuration.php:184
+#: src/Configuration.php:183 src/Configuration.php:191
 msgid "right"
 msgstr "вправо"
 
@@ -242,7 +242,7 @@ msgstr "вправо"
 msgid "save"
 msgstr "Сохранить"
 
-#: src/Configuration.php:177 src/Configuration.php:185
+#: src/Configuration.php:184 src/Configuration.php:192
 msgid "up"
 msgstr "вверх"
 

--- a/resources/lang/sk/messages.po
+++ b/resources/lang/sk/messages.po
@@ -25,11 +25,11 @@ msgstr ""
 msgid "A pedigree chart of an individual’s ancestors."
 msgstr "Rodokmeň predkov jednotlivca"
 
-#: src/Configuration.php:414
+#: src/Configuration.php:421
 msgid "Abbreviate given names first"
 msgstr "Najprv skrátiť krstné mená"
 
-#: src/Configuration.php:415
+#: src/Configuration.php:422
 msgid "Abbreviate surnames first"
 msgstr "Najprv skrátiť priezviská"
 
@@ -41,7 +41,7 @@ msgstr ""
 msgid "Add a mother"
 msgstr ""
 
-#: src/Configuration.php:413
+#: src/Configuration.php:420
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automaticky (podľa tradície priezvisk stromu)"
 
@@ -228,15 +228,15 @@ msgstr ""
 msgid "cancel"
 msgstr "zrušiť"
 
-#: src/Configuration.php:178 src/Configuration.php:186
+#: src/Configuration.php:185 src/Configuration.php:193
 msgid "down"
 msgstr "dole"
 
-#: src/Configuration.php:175 src/Configuration.php:183
+#: src/Configuration.php:182 src/Configuration.php:190
 msgid "left"
 msgstr "vľavo"
 
-#: src/Configuration.php:176 src/Configuration.php:184
+#: src/Configuration.php:183 src/Configuration.php:191
 msgid "right"
 msgstr "vpravo"
 
@@ -244,7 +244,7 @@ msgstr "vpravo"
 msgid "save"
 msgstr "uložiť"
 
-#: src/Configuration.php:177 src/Configuration.php:185
+#: src/Configuration.php:184 src/Configuration.php:192
 msgid "up"
 msgstr "hore"
 

--- a/resources/lang/sl/messages.po
+++ b/resources/lang/sl/messages.po
@@ -25,11 +25,11 @@ msgstr ""
 msgid "A pedigree chart of an individual’s ancestors."
 msgstr "Rodovnik prednikov osebe."
 
-#: src/Configuration.php:414
+#: src/Configuration.php:421
 msgid "Abbreviate given names first"
 msgstr "Najprej skrajšaj osebna imena"
 
-#: src/Configuration.php:415
+#: src/Configuration.php:422
 msgid "Abbreviate surnames first"
 msgstr "Najprej skrajšaj priimke"
 
@@ -41,7 +41,7 @@ msgstr ""
 msgid "Add a mother"
 msgstr ""
 
-#: src/Configuration.php:413
+#: src/Configuration.php:420
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Samodejno (glede na drevesno tradicijo priimkov)"
 
@@ -232,15 +232,15 @@ msgstr ""
 msgid "cancel"
 msgstr "Prekliči"
 
-#: src/Configuration.php:178 src/Configuration.php:186
+#: src/Configuration.php:185 src/Configuration.php:193
 msgid "down"
 msgstr "Dol"
 
-#: src/Configuration.php:175 src/Configuration.php:183
+#: src/Configuration.php:182 src/Configuration.php:190
 msgid "left"
 msgstr "Levo"
 
-#: src/Configuration.php:176 src/Configuration.php:184
+#: src/Configuration.php:183 src/Configuration.php:191
 msgid "right"
 msgstr "Desno"
 
@@ -248,7 +248,7 @@ msgstr "Desno"
 msgid "save"
 msgstr "Shrani"
 
-#: src/Configuration.php:177 src/Configuration.php:185
+#: src/Configuration.php:184 src/Configuration.php:192
 msgid "up"
 msgstr "Gor"
 

--- a/resources/lang/sv/messages.po
+++ b/resources/lang/sv/messages.po
@@ -22,11 +22,11 @@ msgstr ""
 msgid "A pedigree chart of an individual’s ancestors."
 msgstr "En antavla för en individs anor."
 
-#: src/Configuration.php:414
+#: src/Configuration.php:421
 msgid "Abbreviate given names first"
 msgstr "Förkorta förnamn först"
 
-#: src/Configuration.php:415
+#: src/Configuration.php:422
 msgid "Abbreviate surnames first"
 msgstr "Förkorta efternamn först"
 
@@ -38,7 +38,7 @@ msgstr ""
 msgid "Add a mother"
 msgstr ""
 
-#: src/Configuration.php:413
+#: src/Configuration.php:420
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatiskt (baserat på trädets efternamnstradition)"
 
@@ -225,15 +225,15 @@ msgstr ""
 msgid "cancel"
 msgstr "avbryt"
 
-#: src/Configuration.php:178 src/Configuration.php:186
+#: src/Configuration.php:185 src/Configuration.php:193
 msgid "down"
 msgstr "ner"
 
-#: src/Configuration.php:175 src/Configuration.php:183
+#: src/Configuration.php:182 src/Configuration.php:190
 msgid "left"
 msgstr "vänster"
 
-#: src/Configuration.php:176 src/Configuration.php:184
+#: src/Configuration.php:183 src/Configuration.php:191
 msgid "right"
 msgstr "höger"
 
@@ -241,7 +241,7 @@ msgstr "höger"
 msgid "save"
 msgstr "spara"
 
-#: src/Configuration.php:177 src/Configuration.php:185
+#: src/Configuration.php:184 src/Configuration.php:192
 msgid "up"
 msgstr "upp"
 

--- a/resources/lang/uk/messages.po
+++ b/resources/lang/uk/messages.po
@@ -23,11 +23,11 @@ msgstr ""
 msgid "A pedigree chart of an individual’s ancestors."
 msgstr "Діаграма предків персони у вигляді дерева."
 
-#: src/Configuration.php:414
+#: src/Configuration.php:421
 msgid "Abbreviate given names first"
 msgstr "Спершу скорочувати імена"
 
-#: src/Configuration.php:415
+#: src/Configuration.php:422
 msgid "Abbreviate surnames first"
 msgstr "Спершу скорочувати прізвища"
 
@@ -39,7 +39,7 @@ msgstr ""
 msgid "Add a mother"
 msgstr ""
 
-#: src/Configuration.php:413
+#: src/Configuration.php:420
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Автоматично (за традицією прізвищ дерева)"
 
@@ -226,15 +226,15 @@ msgstr ""
 msgid "cancel"
 msgstr "скасувати"
 
-#: src/Configuration.php:178 src/Configuration.php:186
+#: src/Configuration.php:185 src/Configuration.php:193
 msgid "down"
 msgstr "вниз"
 
-#: src/Configuration.php:175 src/Configuration.php:183
+#: src/Configuration.php:182 src/Configuration.php:190
 msgid "left"
 msgstr "ліворуч"
 
-#: src/Configuration.php:176 src/Configuration.php:184
+#: src/Configuration.php:183 src/Configuration.php:191
 msgid "right"
 msgstr "праворуч"
 
@@ -242,7 +242,7 @@ msgstr "праворуч"
 msgid "save"
 msgstr "зберегти"
 
-#: src/Configuration.php:177 src/Configuration.php:185
+#: src/Configuration.php:184 src/Configuration.php:192
 msgid "up"
 msgstr "вгору"
 

--- a/resources/lang/vi/messages.po
+++ b/resources/lang/vi/messages.po
@@ -22,11 +22,11 @@ msgstr ""
 msgid "A pedigree chart of an individual’s ancestors."
 msgstr "Biểu đồ phả hệ của tổ tiên của một cá nhân."
 
-#: src/Configuration.php:414
+#: src/Configuration.php:421
 msgid "Abbreviate given names first"
 msgstr "Viết tắt tên gọi trước"
 
-#: src/Configuration.php:415
+#: src/Configuration.php:422
 msgid "Abbreviate surnames first"
 msgstr "Viết tắt họ trước"
 
@@ -38,7 +38,7 @@ msgstr ""
 msgid "Add a mother"
 msgstr ""
 
-#: src/Configuration.php:413
+#: src/Configuration.php:420
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Tự động (dựa trên truyền thống họ của cây phả hệ)"
 
@@ -225,15 +225,15 @@ msgstr ""
 msgid "cancel"
 msgstr "Hủy bỏ"
 
-#: src/Configuration.php:178 src/Configuration.php:186
+#: src/Configuration.php:185 src/Configuration.php:193
 msgid "down"
 msgstr "Từ trên xuống"
 
-#: src/Configuration.php:175 src/Configuration.php:183
+#: src/Configuration.php:182 src/Configuration.php:190
 msgid "left"
 msgstr "Từ trái sang phải"
 
-#: src/Configuration.php:176 src/Configuration.php:184
+#: src/Configuration.php:183 src/Configuration.php:191
 msgid "right"
 msgstr "Từ phải sang trái"
 
@@ -241,7 +241,7 @@ msgstr "Từ phải sang trái"
 msgid "save"
 msgstr "lưu"
 
-#: src/Configuration.php:177 src/Configuration.php:185
+#: src/Configuration.php:184 src/Configuration.php:192
 msgid "up"
 msgstr "Từ dưới lên"
 

--- a/resources/lang/zh-Hans/messages.po
+++ b/resources/lang/zh-Hans/messages.po
@@ -22,11 +22,11 @@ msgstr ""
 msgid "A pedigree chart of an individual’s ancestors."
 msgstr "个人祖先的世系图"
 
-#: src/Configuration.php:414
+#: src/Configuration.php:421
 msgid "Abbreviate given names first"
 msgstr "优先缩写名字"
 
-#: src/Configuration.php:415
+#: src/Configuration.php:422
 msgid "Abbreviate surnames first"
 msgstr "优先缩写姓氏"
 
@@ -38,7 +38,7 @@ msgstr ""
 msgid "Add a mother"
 msgstr ""
 
-#: src/Configuration.php:413
+#: src/Configuration.php:420
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "自动（根据族谱的姓氏传统）"
 
@@ -222,15 +222,15 @@ msgstr ""
 msgid "cancel"
 msgstr "取消"
 
-#: src/Configuration.php:178 src/Configuration.php:186
+#: src/Configuration.php:185 src/Configuration.php:193
 msgid "down"
 msgstr "祖辈在下"
 
-#: src/Configuration.php:175 src/Configuration.php:183
+#: src/Configuration.php:182 src/Configuration.php:190
 msgid "left"
 msgstr "祖辈在左"
 
-#: src/Configuration.php:176 src/Configuration.php:184
+#: src/Configuration.php:183 src/Configuration.php:191
 msgid "right"
 msgstr "祖辈在右"
 
@@ -238,7 +238,7 @@ msgstr "祖辈在右"
 msgid "save"
 msgstr "保存"
 
-#: src/Configuration.php:177 src/Configuration.php:185
+#: src/Configuration.php:184 src/Configuration.php:192
 msgid "up"
 msgstr "祖辈在上"
 

--- a/resources/lang/zh-Hant/messages.po
+++ b/resources/lang/zh-Hant/messages.po
@@ -22,11 +22,11 @@ msgstr ""
 msgid "A pedigree chart of an individual’s ancestors."
 msgstr "個人祖先的世系圖。"
 
-#: src/Configuration.php:414
+#: src/Configuration.php:421
 msgid "Abbreviate given names first"
 msgstr "優先縮寫名字"
 
-#: src/Configuration.php:415
+#: src/Configuration.php:422
 msgid "Abbreviate surnames first"
 msgstr "優先縮寫姓氏"
 
@@ -38,7 +38,7 @@ msgstr ""
 msgid "Add a mother"
 msgstr ""
 
-#: src/Configuration.php:413
+#: src/Configuration.php:420
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "自動（根據族譜的姓氏傳統）"
 
@@ -222,15 +222,15 @@ msgstr ""
 msgid "cancel"
 msgstr "取消"
 
-#: src/Configuration.php:178 src/Configuration.php:186
+#: src/Configuration.php:185 src/Configuration.php:193
 msgid "down"
 msgstr "祖輩在下"
 
-#: src/Configuration.php:175 src/Configuration.php:183
+#: src/Configuration.php:182 src/Configuration.php:190
 msgid "left"
 msgstr "祖輩在左"
 
-#: src/Configuration.php:176 src/Configuration.php:184
+#: src/Configuration.php:183 src/Configuration.php:191
 msgid "right"
 msgstr "祖輩在右"
 
@@ -238,7 +238,7 @@ msgstr "祖輩在右"
 msgid "save"
 msgstr "保存"
 
-#: src/Configuration.php:177 src/Configuration.php:185
+#: src/Configuration.php:184 src/Configuration.php:192
 msgid "up"
 msgstr "祖輩在上"
 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -80,6 +80,13 @@ class Configuration
     public const string MATERNAL_COLOR_DEFAULT = '#d06f94';
 
     /**
+     * The memoised route parameters, resolved on first use.
+     *
+     * @var array{generations: int, layout: string, showNicknames: string, showAddParentLinks: string}|null
+     */
+    private ?array $routeToggleParams = null;
+
+    /**
      * Configuration constructor.
      *
      * @param ServerRequestInterface $request
@@ -456,11 +463,17 @@ class Configuration
      * colours, name abbreviation) live in the client-side chart options and are
      * deliberately not listed here.
      *
-     * @return array<string, int|string>
+     * Memoised because the update route is built once per node, while
+     * AbstractModule::getPreference() issues a database query on every call —
+     * resolving four settings per node would put the query count in linear
+     * proportion to the tree size. The configuration is constructed per request,
+     * so the resolved values cannot go stale within its lifetime.
+     *
+     * @return array{generations: int, layout: string, showNicknames: string, showAddParentLinks: string}
      */
     public function getRouteToggleParams(): array
     {
-        return [
+        return $this->routeToggleParams ??= [
             'generations'        => $this->getGenerations(),
             'layout'             => $this->getLayout(),
             'showNicknames'      => $this->getShowNicknames() ? '1' : '0',

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -445,4 +445,26 @@ class Configuration
             ? $value
             : NameAbbreviation::AUTO;
     }
+
+    /**
+     * Returns the settings that have to travel with the re-centering URL.
+     *
+     * The update route rebuilds the node data server-side, so every setting the
+     * data facade reads while building it must be forwarded — otherwise
+     * clicking a person to re-center silently resets that setting to the module
+     * preference default. Settings the browser applies on its own (family
+     * colours, name abbreviation) live in the client-side chart options and are
+     * deliberately not listed here.
+     *
+     * @return array<string, int|string>
+     */
+    public function getRouteToggleParams(): array
+    {
+        return [
+            'generations'        => $this->getGenerations(),
+            'layout'             => $this->getLayout(),
+            'showNicknames'      => $this->getShowNicknames() ? '1' : '0',
+            'showAddParentLinks' => $this->getShowAddParentLinks() ? '1' : '0',
+        ];
+    }
 }

--- a/src/Facade/DataFacade.php
+++ b/src/Facade/DataFacade.php
@@ -269,10 +269,7 @@ class DataFacade
     {
         return $this->chartUrl(
             $individual,
-            [
-                'generations' => $this->configuration->getGenerations(),
-                'layout'      => $this->configuration->getLayout(),
-            ]
+            $this->configuration->getRouteToggleParams()
         );
     }
 }

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/webtrees-pedigree-chart.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Webtrees\PedigreeChart\Test;
+
+use Fisharebest\Webtrees\Module\AbstractModule;
+use MagicSunday\Webtrees\PedigreeChart\Configuration;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Validates how the chart configuration assembles the parameters that survive
+ * a chart re-centering request.
+ */
+#[CoversClass(Configuration::class)]
+final class ConfigurationTest extends TestCase
+{
+    /**
+     * The individual getters resolve request parameters against module
+     * preferences, and `AbstractModule::getPreference()` is final and reads the
+     * database, so exercising them needs a module backed by a real preference
+     * store. This repository has no such harness yet; overriding the getters
+     * keeps this test on the part that is actually under test, namely which
+     * settings `getRouteToggleParams()` collects.
+     *
+     * Once a preference-backed harness exists, this should resolve the getters
+     * for real so the parameter values are covered as well, not just the keys.
+     *
+     * @return Configuration
+     */
+    private function configurationWithFixedSettings(): Configuration
+    {
+        return new class(self::createStub(ServerRequestInterface::class), self::createStub(AbstractModule::class)) extends Configuration {
+            public function getGenerations(): int
+            {
+                return 5;
+            }
+
+            public function getLayout(): string
+            {
+                return 'down';
+            }
+
+            public function getShowNicknames(): bool
+            {
+                return true;
+            }
+
+            public function getShowAddParentLinks(): bool
+            {
+                return false;
+            }
+        };
+    }
+
+    /**
+     * The re-centering URL is rebuilt from these parameters. Every setting the
+     * data facade reads while building node data has to appear here, otherwise
+     * clicking a person silently resets it to the module preference default.
+     */
+    #[Test]
+    public function routeToggleParamsCarryEverySettingTheFacadeReads(): void
+    {
+        $params = $this->configurationWithFixedSettings()->getRouteToggleParams();
+
+        self::assertSame(
+            [
+                'generations'        => 5,
+                'layout'             => 'down',
+                'showNicknames'      => '1',
+                'showAddParentLinks' => '0',
+            ],
+            $params
+        );
+    }
+}

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -89,6 +89,9 @@ final class ConfigurationTest extends TestCase
     }
 
     /**
+     * Builds a Configuration from the given query parameters and seeded module
+     * preferences.
+     *
      * @param array<string, string> $queryParams
      * @param array<string, string> $preferences
      */
@@ -131,9 +134,10 @@ final class ConfigurationTest extends TestCase
     }
 
     /**
-     * The disabled polarity, which the enabled case cannot discriminate: with
-     * both toggles on, a raw passthrough of the query parameters would produce
-     * the same result as the intended mapping.
+     * Locks the false → '0' branch of the boolean mapping, which the enabled
+     * case cannot: a regression that hardcodes '1', leaves a toggle stuck on, or
+     * lets it fall through to an enabled default passes the enabled case above
+     * but must fail here.
      */
     #[Test]
     public function routeParamsCarryTheDisabledDisplaySettings(): void

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -11,76 +11,180 @@ declare(strict_types=1);
 
 namespace MagicSunday\Webtrees\PedigreeChart\Test;
 
+use Fig\Http\Message\RequestMethodInterface;
+use Fisharebest\Webtrees\DB;
 use Fisharebest\Webtrees\Module\AbstractModule;
+use Fisharebest\Webtrees\Services\ChartService;
+use GuzzleHttp\Psr7\ServerRequest;
+use Illuminate\Database\Schema\Blueprint;
 use MagicSunday\Webtrees\PedigreeChart\Configuration;
+use MagicSunday\Webtrees\PedigreeChart\Facade\DataFacade;
+use MagicSunday\Webtrees\PedigreeChart\Module;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Psr\Http\Message\ServerRequestInterface;
+use ReflectionProperty;
 
 /**
- * Validates how the chart configuration assembles the parameters that survive
- * a chart re-centering request.
+ * Verifies which settings travel with the re-centering URL and that each one is
+ * resolved from the request or, failing that, from the module preference.
+ *
+ * Uses an in-memory SQLite DB because AbstractModule::getPreference() is final
+ * and cannot be stubbed; the real implementation reads from the
+ * `module_setting` table.
  */
 #[CoversClass(Configuration::class)]
 final class ConfigurationTest extends TestCase
 {
     /**
-     * The individual getters resolve request parameters against module
-     * preferences, and `AbstractModule::getPreference()` is final and reads the
-     * database, so exercising them needs a module backed by a real preference
-     * store. This repository has no such harness yet; overriding the getters
-     * keeps this test on the part that is actually under test, namely which
-     * settings `getRouteToggleParams()` collects.
+     * Boots an in-memory SQLite + minimal `module_setting` schema once per
+     * process; subsequent calls just truncate the table and re-seed.
      *
-     * Once a preference-backed harness exists, this should resolve the getters
-     * for real so the parameter values are covered as well, not just the keys.
-     *
-     * @return Configuration
+     * @param array<string, string> $preferences
      */
-    private function configurationWithFixedSettings(): Configuration
+    private function createModuleWithPreferences(array $preferences): Module
     {
-        return new class(self::createStub(ServerRequestInterface::class), self::createStub(AbstractModule::class)) extends Configuration {
-            public function getGenerations(): int
-            {
-                return 5;
-            }
+        static $initialised = false;
 
-            public function getLayout(): string
-            {
-                return 'down';
-            }
+        if ($initialised === false) {
+            $database = new DB();
+            $database->addConnection([
+                'driver'   => 'sqlite',
+                'database' => ':memory:',
+            ]);
+            $database->setAsGlobal();
+            $database->bootEloquent();
+            DB::connection()->getSchemaBuilder()->create('module_setting', static function (Blueprint $table): void {
+                $table->string('module_name');
+                $table->string('setting_name');
+                $table->string('setting_value');
+            });
 
-            public function getShowNicknames(): bool
-            {
-                return true;
-            }
+            $initialised = true;
+        }
 
-            public function getShowAddParentLinks(): bool
-            {
-                return false;
-            }
-        };
+        DB::table('module_setting')->delete();
+
+        if ($preferences !== []) {
+            DB::table('module_setting')->insert(
+                array_map(
+                    static fn (string $name, string $value): array => [
+                        'module_name'   => 'webtrees-pedigree-chart',
+                        'setting_name'  => $name,
+                        'setting_value' => $value,
+                    ],
+                    array_keys($preferences),
+                    array_values($preferences),
+                )
+            );
+        }
+
+        $chartService = self::createStub(ChartService::class);
+        $module       = new Module($chartService, new DataFacade());
+
+        $reflection = new ReflectionProperty(AbstractModule::class, 'name');
+        $reflection->setValue($module, 'webtrees-pedigree-chart');
+
+        return $module;
     }
 
     /**
-     * The re-centering URL is rebuilt from these parameters. Every setting the
-     * data facade reads while building node data has to appear here, otherwise
-     * clicking a person silently resets it to the module preference default.
+     * @param array<string, string> $queryParams
+     * @param array<string, string> $preferences
+     */
+    private function buildConfiguration(array $queryParams, array $preferences): Configuration
+    {
+        $request = (new ServerRequest(RequestMethodInterface::METHOD_GET, '/'))
+            ->withQueryParams($queryParams);
+
+        return new Configuration($request, $this->createModuleWithPreferences($preferences));
+    }
+
+    /**
+     * The enabled polarity. The boolean settings have to leave as the strings
+     * `'1'`/`'0'`, because `Validator::boolean()` compares strictly — an int
+     * would match neither branch and fall back to the preference default, which
+     * is the very regression this list prevents.
      */
     #[Test]
-    public function routeToggleParamsCarryEverySettingTheFacadeReads(): void
+    public function routeParamsCarryTheEnabledDisplaySettings(): void
     {
-        $params = $this->configurationWithFixedSettings()->getRouteToggleParams();
+        $configuration = $this->buildConfiguration(
+            [
+                'generations'        => '5',
+                'layout'             => Configuration::LAYOUT_TOPBOTTOM,
+                'showNicknames'      => '1',
+                'showAddParentLinks' => '1',
+            ],
+            []
+        );
 
         self::assertSame(
             [
                 'generations'        => 5,
-                'layout'             => 'down',
+                'layout'             => Configuration::LAYOUT_TOPBOTTOM,
                 'showNicknames'      => '1',
+                'showAddParentLinks' => '1',
+            ],
+            $configuration->getRouteToggleParams()
+        );
+    }
+
+    /**
+     * The disabled polarity, which the enabled case cannot discriminate: with
+     * both toggles on, a raw passthrough of the query parameters would produce
+     * the same result as the intended mapping.
+     */
+    #[Test]
+    public function routeParamsCarryTheDisabledDisplaySettings(): void
+    {
+        $configuration = $this->buildConfiguration(
+            [
+                'generations'        => '3',
+                'layout'             => Configuration::LAYOUT_LEFTRIGHT,
+                'showNicknames'      => '0',
                 'showAddParentLinks' => '0',
             ],
-            $params
+            []
+        );
+
+        self::assertSame(
+            [
+                'generations'        => 3,
+                'layout'             => Configuration::LAYOUT_LEFTRIGHT,
+                'showNicknames'      => '0',
+                'showAddParentLinks' => '0',
+            ],
+            $configuration->getRouteToggleParams()
+        );
+    }
+
+    /**
+     * The scenario the forwarding exists for: without any request parameter the
+     * effective value is the module preference, and that resolved value — not an
+     * echo of the URL — is what has to travel on.
+     */
+    #[Test]
+    public function routeParamsResolveFromModulePreferencesWhenTheRequestIsEmpty(): void
+    {
+        $configuration = $this->buildConfiguration(
+            [],
+            [
+                'default_generations'        => '7',
+                'default_layout'             => Configuration::LAYOUT_RIGHTLEFT,
+                'default_showNicknames'      => '1',
+                'default_showAddParentLinks' => '1',
+            ]
+        );
+
+        self::assertSame(
+            [
+                'generations'        => 7,
+                'layout'             => Configuration::LAYOUT_RIGHTLEFT,
+                'showNicknames'      => '1',
+                'showAddParentLinks' => '1',
+            ],
+            $configuration->getRouteToggleParams()
         );
     }
 }


### PR DESCRIPTION
Clicking a person to re-center the pedigree chart rebuilds the node data
server-side, but `getUpdateRoute()` forwarded only `generations` and `layout`.
Every other display setting the data facade reads while building that data fell
back to the module preference default — nickname display and the add-parent
placeholders were silently reset on every re-center.

`Configuration::getRouteToggleParams()` now collects the full server-relevant
set — `generations`, `layout`, `showNicknames`, `showAddParentLinks` — and
`getUpdateRoute()` forwards it. The booleans travel as the strings `'1'`/`'0'`
because `Validator::boolean()` compares strictly. The method is memoised: the
update route is built once per node while `AbstractModule::getPreference()`
queries the database on every call, so resolving the settings per node would
scale the query count with the tree size. The configuration is constructed once
per request, so the cached values cannot go stale within its lifetime.

Settings the browser applies on its own (family colours, name abbreviation) live
in the client-side chart options and are deliberately not forwarded.

`tests/ConfigurationTest.php` pins the behaviour against a real `module_setting`
table (in-memory SQLite), because `AbstractModule::getPreference()` is `final`
and cannot be stubbed. It resolves the getters for real and covers the enabled
polarity, the disabled polarity, and preference resolution when the request
carries no parameter.

Fixes #118
