### PR TITLE
Make the type annotations survive TypeScript 7

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -13,7 +13,6 @@
         "lib": ["ES2022", "DOM"],
         "types": ["jest"],
         "ignoreDeprecations": "6.0",
-        "baseUrl": ".",
         "paths": {
             "resources/js/modules/*": ["./resources/js/modules/*"]
         }

--- a/resources/js/modules/chart.js
+++ b/resources/js/modules/chart.js
@@ -36,7 +36,7 @@ export default class Chart {
         this._configuration = configuration;
         this._parent = parent;
         this._hierarchy = new Hierarchy(this._configuration);
-        /** @type {Data|null} */
+        /** @type {NodeDatum|null} */
         this._data = null;
         /** @type {Svg} */
         this._svg = /** @type {Svg} */ (/** @type {unknown} */ (null));
@@ -65,7 +65,7 @@ export default class Chart {
     /**
      * Returns the chart data.
      *
-     * @returns {Data|null}
+     * @returns {NodeDatum|null}
      */
     get data() {
         return this._data;
@@ -74,7 +74,7 @@ export default class Chart {
     /**
      * Sets the chart data.
      *
-     * @param {Data} value The chart data
+     * @param {NodeDatum} value The chart data
      */
     set data(value) {
         this._data = value;
@@ -186,7 +186,7 @@ export default class Chart {
      * Method triggers either the "update" or "individual" method on the click
      * on a person.
      *
-     * @param {object} data The D3 data object
+     * @param {NodeDatum} data The D3 data object
      *
      * @private
      */

--- a/resources/js/modules/data.js
+++ b/resources/js/modules/data.js
@@ -41,11 +41,38 @@
  */
 
 /**
+ * A single node of the chart tree as emitted by the PHP Node::jsonSerialize().
+ * The node's own person data is always present, while "parents" is omitted
+ * entirely for nodes without any known ancestor.
+ *
+ * @typedef {object} NodeDatum
+ * @property {Data}        data      The person data of this node
+ * @property {NodeDatum[]} [parents] The ancestor nodes, omitted when the node has none
+ */
+
+/**
+ * The datum bound to the name <text> elements of a person box. It carries the
+ * person node plus the pre-resolved layout flags the name renderer needs.
+ *
  * @typedef {object} NameElementData
- * @property {{data: Data}} data
- * @property {boolean} [isRtl]
- * @property {boolean} [isAltRtl]
- * @property {boolean} [withImage]
+ * @property {NodeDatum} data       The person node the name belongs to
+ * @property {boolean}   [isRtl]    Whether the primary name renders right-to-left
+ * @property {boolean}   [isAltRtl] Whether the alternative name renders right-to-left
+ * @property {boolean}   [withImage] Whether the box reserves room for a thumbnail
+ */
+
+/**
+ * The datum bound to the date <text> elements of a person box. Vertical
+ * layouts render a single combined timespan row (label + withImage only),
+ * while horizontal layouts render one row per event, each carrying its own
+ * glyph and event marker.
+ *
+ * @typedef {object} DateElementData
+ * @property {string}  label      The formatted date text
+ * @property {boolean} withImage  Whether the box reserves room for a thumbnail
+ * @property {string}  [icon]     The event glyph, horizontal layouts only
+ * @property {boolean} [birth]    TRUE for the birth row
+ * @property {boolean} [death]    TRUE for the death row
  */
 
 /**

--- a/resources/js/modules/hierarchy.js
+++ b/resources/js/modules/hierarchy.js
@@ -14,6 +14,14 @@ import { LAYOUT_VERTICAL_NODE_HEIGHT_OFFSET } from "./constants.js";
  */
 
 /**
+ * A single person node of the chart tree, carrying the server-emitted node
+ * datum as its payload. The tree layout additionally assigns x/y coordinates
+ * in place, so laid-out point nodes satisfy this type as well.
+ *
+ * @typedef {HierarchyNode<NodeDatum>} Individual
+ */
+
+/**
  * This class handles the hierarchical data.
  *
  * @author  Rico Sonntag <mail@ricosonntag.de>
@@ -37,7 +45,7 @@ export default class Hierarchy {
     /**
      * Initialize the hierarchical chart data.
      *
-     * @param {object} datum The JSON encoded chart data
+     * @param {NodeDatum} datum The JSON encoded chart data
      */
     init(datum) {
         // Adjust box height if we are going to display the alternative names

--- a/resources/js/modules/index.js
+++ b/resources/js/modules/index.js
@@ -28,17 +28,17 @@ export class PedigreeChart {
      * @param {object} options  A list of options passed from outside to the application
      *
      * @param {{zoom: string, move: string}} options.labels
-     * @param {boolean}  options.rtl
-     * @param {number}   options.generations
-     * @param {string}   options.treeLayout
-     * @param {boolean}  options.openNewTabOnClick
-     * @param {boolean}  options.showAlternativeName
-     * @param {boolean}  options.showFamilyColors
-     * @param {string}   options.paternalColor
-     * @param {string}   options.maternalColor
-     * @param {string}   options.nameAbbreviation
-     * @param {string[]} options.cssFiles
-     * @param {Data[]}   options.data
+     * @param {boolean}   options.rtl
+     * @param {number}    options.generations
+     * @param {string}    options.treeLayout
+     * @param {boolean}   options.openNewTabOnClick
+     * @param {boolean}   options.showAlternativeName
+     * @param {boolean}   options.showFamilyColors
+     * @param {string}    options.paternalColor
+     * @param {string}    options.maternalColor
+     * @param {string}    options.nameAbbreviation
+     * @param {string[]}  options.cssFiles
+     * @param {NodeDatum} options.data
      */
     constructor(selector, options) {
         this._selector = selector;
@@ -128,7 +128,7 @@ export class PedigreeChart {
     /**
      * Draws the chart.
      *
-     * @param {object} data The JSON encoded chart data
+     * @param {NodeDatum} data The JSON encoded chart data
      */
     draw(data) {
         this._chart.data = data;

--- a/resources/js/modules/tree.js
+++ b/resources/js/modules/tree.js
@@ -11,7 +11,7 @@ import LinkDrawer from "./tree/link-drawer.js";
 /**
  * @import Svg from "./chart/svg.js"
  * @import Configuration from "./configuration.js"
- * @import Hierarchy from "./hierarchy.js"
+ * @import Hierarchy, { Individual } from "./hierarchy.js"
  */
 
 /**
@@ -49,7 +49,7 @@ export default class Tree {
     /**
      * Draw the tree.
      *
-     * @param {object} source The root object
+     * @param {Individual} source The root object
      *
      * @public
      */

--- a/resources/js/modules/tree/date.js
+++ b/resources/js/modules/tree/date.js
@@ -153,9 +153,9 @@ export default class DateRenderer {
     /**
      * Truncates a date value.
      *
-     * @param {object} object         The D3 object containing the text value
-     * @param {string} date           The date value to truncate
-     * @param {number} availableWidth The total available width the text could take
+     * @param {Selection<any, any, any, any>} object         The D3 element containing the text value
+     * @param {string}                        date           The date value to truncate
+     * @param {number}                        availableWidth The total available width the text could take
      *
      * @returns {string}
      *
@@ -184,8 +184,9 @@ export default class DateRenderer {
     }
 
     /**
+     * Returns the horizontal text position of a date row.
      *
-     * @param {object} d
+     * @param {DateElementData} d The date element datum
      *
      * @returns {number}
      *
@@ -202,9 +203,9 @@ export default class DateRenderer {
      * Measures the given text and return its width depending on the used font
      * (including size and weight).
      *
-     * @param {string} text
-     * @param {string} fontSize
-     * @param {number} fontWeight
+     * @param {string}        text       The text to measure
+     * @param {string}        fontSize   The CSS font-size string
+     * @param {string|number} fontWeight The CSS font-weight
      *
      * @returns {number}
      *

--- a/resources/js/modules/tree/family-color.js
+++ b/resources/js/modules/tree/family-color.js
@@ -9,6 +9,10 @@ import { familyBranchHsl, familyCenterHsl, hexToHsl } from "@magicsunday/webtree
 import { SEX_FEMALE, SEX_MALE } from "../constants.js";
 
 /**
+ * @import { Individual } from "../hierarchy.js"
+ */
+
+/**
  * Matches Configuration::MAX_GENERATIONS (PHP). The chart-lib picker-color
  * interpolation needs to know the module's maximum depth so the outermost ring
  * lands on the configured paternal/maternal color exactly.
@@ -52,7 +56,7 @@ export default class FamilyColor {
      * Returns an HSL color string for a hierarchy node, or null when no color
      * should be applied.
      *
-     * @param {object} datum The D3 hierarchy datum
+     * @param {Individual} datum The D3 hierarchy datum
      *
      * @returns {string|null}
      */
@@ -86,7 +90,7 @@ export default class FamilyColor {
      * paternal/maternal side, in [0, 1]. Mirrors fan-chart's `half =
      * refMidpoint / 0.5` for the equivalent radial geometry.
      *
-     * @param {object} datum
+     * @param {Individual} datum The D3 hierarchy datum
      *
      * @returns {number}
      *
@@ -147,9 +151,9 @@ export default class FamilyColor {
      * Walks the parent chain until the depth-1 ancestor (= a direct parent of
      * the root individual). Returns null if no such ancestor exists.
      *
-     * @param {object} datum
+     * @param {Individual} datum The D3 hierarchy datum
      *
-     * @returns {Object|null}
+     * @returns {Individual|null}
      *
      * @private
      */

--- a/resources/js/modules/tree/name.js
+++ b/resources/js/modules/tree/name.js
@@ -391,9 +391,9 @@ export default class Name {
     /**
      * Creates the data array for the names.
      *
-     * @param {object}             parent
-     * @param {LabelElementData[]} names
-     * @param {number}             availableWidth
+     * @param {Selection<any, any, any, any>} parent         The D3 text element the names are attached to
+     * @param {LabelElementData[]}            names          The name labels to truncate
+     * @param {number}                        availableWidth The total available width the text could take
      *
      * @returns {LabelElementData[]}
      *
@@ -449,8 +449,9 @@ export default class Name {
     }
 
     /**
+     * Returns the horizontal text position of a name row.
      *
-     * @param {object} d
+     * @param {NameElementData} d The name element datum
      *
      * @returns {number}
      *
@@ -467,9 +468,9 @@ export default class Name {
      * Measures the given text and return its width depending on the used font
      * (including size and weight).
      *
-     * @param {string} text
-     * @param {string} fontSize
-     * @param {number} fontWeight
+     * @param {string}        text       The text to measure
+     * @param {string}        fontSize   The CSS font-size string
+     * @param {string|number} fontWeight The CSS font-weight
      *
      * @returns {number}
      *

--- a/resources/js/modules/tree/node-drawer.js
+++ b/resources/js/modules/tree/node-drawer.js
@@ -13,13 +13,10 @@ import ImageBox from "../chart/box/image.js";
 import TextBox from "../chart/box/text.js";
 
 /**
- * @import { HierarchyNode } from "d3-hierarchy"
  * @import { Selection } from "d3-selection"
  * @import Svg from "../chart/svg.js"
- * @import Hierarchy from "../hierarchy.js"
+ * @import Hierarchy, { Individual } from "../hierarchy.js"
  * @import Configuration from "../configuration.js"
- *
- * @typedef {HierarchyNode<any>} Individual
  */
 
 /**
@@ -60,7 +57,7 @@ export default class NodeDrawer {
      * `null` when family colors are disabled — leaving the CSS sex-based fill
      * in place.
      *
-     * @param {object} person The d3 hierarchy datum
+     * @param {Individual} person The d3 hierarchy datum
      *
      * @return {string|null}
      *
@@ -73,8 +70,8 @@ export default class NodeDrawer {
     /**
      * Draw the person boxes.
      *
-     * @param {Array}  nodes  Array of descendant nodes
-     * @param {object} source The root object
+     * @param {Individual[]} nodes  Array of descendant nodes
+     * @param {Individual}   source The root object
      *
      * @public
      */
@@ -195,7 +192,7 @@ export default class NodeDrawer {
     }
 
     /**
-     * @param {object} person The d3 hierarchy datum
+     * @param {Individual} person The d3 hierarchy datum
      *
      * @returns {boolean} TRUE when the node is an "add parent" placeholder
      *                    (empty xref + populated url) rather than a real

--- a/resources/views/modules/pedigree-chart/chart.phtml
+++ b/resources/views/modules/pedigree-chart/chart.phtml
@@ -11,14 +11,15 @@ declare(strict_types=1);
 
 use Fisharebest\Webtrees\View;
 use MagicSunday\Webtrees\PedigreeChart\Configuration;
+use MagicSunday\Webtrees\PedigreeChart\Model\Node;
 
 /**
  * @var string        $javascript
  * @var Configuration $configuration
- * @var array         $id                The unique chart ID
+ * @var string        $id                The unique chart ID
  * @var array         $chartParams
  * @var string[]      $exportStylesheets A list of stylesheets used by SVG export
- * @var array         $data              The chart data
+ * @var Node|null     $data              The chart data tree, JSON-serialized into the chart "data" option
  */
 ?>
 


### PR DESCRIPTION
Preventive. Nothing is broken here today — the `typescript` pin is still `^6.0.3`. But the sibling `webtrees-fan-chart` has already taken the `^7.0.2` bump and went red on it, and this repository carries the identical exposure.

## Why removing baseUrl alone would not have been enough

TypeScript 7 removed the `baseUrl` compiler option **and** tightened property access on the `object` type. The first alone aborts `tsc` before it reports anything else. Dropping `baseUrl` here uncovers **27 follow-up errors** that were never visible — the same masking that made the fan-chart breakage look like a one-line fix.

Fixing them now means the eventual Dependabot bump is a green PR instead of a red one.

## Scope

- `baseUrl` removed; the `paths` values are already config-relative and resolve unchanged without it (supported since TypeScript 4.1).
- `NodeDatum` derived from `Node::jsonSerialize()`. Its `parents` key is optional because the PHP only emits it when the array is non-empty.
- `Individual` defined once in `hierarchy.js` instead of the local duplicate `node-drawer.js` carried.
- **The pin itself is deliberately left alone.** TypeScript 7 was installed only as a local oracle and reverted; `package.json` and `package-lock.json` are untouched. Adopting it is a separate decision, and Dependabot own.

## Three documentation bugs the bare `object` had been hiding

None of these were runtime faults — every call site was already correct, only the docblock lied:

- `Chart._data` holds the tree root node, not a person record
- `options.data` is a single node, not an array
- `measureText()` `fontWeight` receives a CSS string, not a number

## Verification

`tsc` 0 errors under **both** TypeScript 6.0.3 and 7.0.2; `composer ci:test` `rc=0`; 9 tests green; `git diff` on `package.json` / `package-lock.json` empty. No executable line changed — the only non-comment edit in the whole JS diff is the deleted `baseUrl`.

The view template docblock is corrected in a separate commit: it declared `$id` and `$data` as arrays, while `Module.php` assigns `uniqid()` and a `?Node`.

Two findings from review were deliberately **not** folded in, because both need a browser check and have their own scope: #124 (dead spouse and family branches) and #125 (unfinished baseline attribute migration).