### PR TITLE
Run CI once per pull request, not twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
     push:
+        branches: [main, master, '*.x', WIP]
     pull_request:
 
 permissions:


### PR DESCRIPTION
The `ci.yml` workflow triggered on both an unfiltered `push:` and `pull_request:`. For a branch with an open pull request both fire, so the whole matrix ran twice for the same commit — including the contexts required to merge.

The `push` trigger is now scoped to `[main, master]`, matching sibling workflows in this repository that already do so. A pull request still produces its contexts through the unchanged `pull_request` trigger, so the required checks resolve exactly as before; a direct push to `main` and the post-merge state stay covered.

Part of a family-wide alignment: the same unfiltered trigger was present in 13 repositories.