### PR TITLE
Point the commit-subject rule at the shared gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,51 +116,9 @@ Pipeline (`make release X.Y.Z`):
 
 ## PR/commit checklist
 - `composer ci:test` must pass before every commit.
-- Commit subjects and the pull-request title are enforced by
-  `.github/workflows/commit-lint.yml`, which calls
-  `magicsunday/.github/.github/workflows/commit-convention.yml@main`. That workflow
-  holds the normative rule and self-tests it against a decision table before applying
-  it; where this summary and the workflow disagree, the workflow is authoritative on
-  what is *accepted* and this text is what gets fixed — except where this text is
-  deliberately narrower about what is *written* (ASCII `[A-Z]`, below). The invariant to
-  preserve is that this text must never accept a subject the workflow blocks. Both the
-  title and every commit in the pull request are judged, because which of them reaches
-  `main` depends on how the pull request lands: a multi-commit squash uses the title, a
-  single-commit squash keeps that commit's own subject, and a merge or rebase merge
-  keeps the commits' subjects. Checking both makes the rule hold either way. The message
-  body and existing history are never judged. The check is advisory until
-  `commit-convention / Commit convention` is a required context in branch protection.
-- The rule in short: a subject starting with `GH-` must match `^GH-\d+: [A-Z]`, every
-  other subject `^[A-Z]` — a capitalised imperative either way. Two starts are rejected
-  whatever their case: **conventional-commit prefixes**, including the capitalised
-  `Fix:` and the scoped breaking-change `Feat(api)!:` as much as a plain `feat:`, and
-  **path-like starts** such as `src/Module.php: …` and the capitalised
-  `Src/Module.php:fix` — no space after the colon is needed to count. Subjects beginning
-  `Merge ` or `Revert ` pass — by prefix rather than by provenance, and in any case on
-  their leading capital, since neither ban can fire on them: the path ban needs a slash
-  before the first colon with no whitespace in between, and the conventional-commit ban
-  needs one of its type words followed immediately by an optional scope or `!` and then
-  a colon — these have a space there. The same check judges the pull-request title, so
-  never title a pull request `Merge …`. `fixup!` and `squash!` do not pass, so
-  autosquash them before opening the PR. Commit subjects are English, so the documented
-  capital is ASCII `[A-Z]`, while the gate accepts the wider `[[:upper:]]` under the
-  UTF-8 locale it pins — under `LC_ALL=C` that width disappears. The width only ever
-  adds PASSes: the class sits in two accept positions, and its third use — lowercasing
-  the subject before the conventional-commit test — is byte-based and touches ASCII
-  only. This holds for the capital class alone: the gate is **not** a superset of
-  `^[A-Z]`, because the `GH-` routing and the two banned starts above reject capitalised
-  subjects too.
-    - The two patterns stay separate on purpose. Folding them into
-      `^(GH-\d+: )?[A-Z]` breaks the rule: the optional group can be skipped and the
-      `G` of `GH-` then satisfies `[A-Z]` on its own, so `GH-12: fix typo` would pass.
-- Branches for an issue are named exactly `GH-<N>`, where `<N>` is the issue number.
-  The `GH-<N>: ` prefix marks work that belongs to the issue, so a commit on that
-  branch whose concern is something else — a drive-by lint fix, a dependency bump —
-  keeps its own unprefixed subject. The gate keys on the subject alone and never asks
-  which branch a commit sits on, which is what keeps it decidable for commits already
-  on `main`.
-- The PR body closes the issue with a `Closes #<N>` keyword. The `GH-<N>: ` subject
-  prefix is not a GitHub link and closes nothing.
+- Commit subjects — and the pull-request title — are governed by the shared `commit-convention` gate; the normative rule and its full rationale live in `magicsunday/.github/.github/workflows/commit-convention.yml@main`, which self-tests a decision table before applying it. In short: a `GH-`-prefixed subject must match `^GH-\d+: [A-Z]`, every other subject `^[A-Z]` — a capitalised English imperative — and conventional-commit prefixes (`feat:`, `Fix:`, …) as well as path-like starts (`src/…: …`) are rejected whatever their case. It runs on every pull request via `.github/workflows/commit-lint.yml`, advisory until `commit-convention / Commit convention` is a required context in branch protection.
+- Branches for an issue are named exactly `GH-<N>`; the `GH-<N>: ` prefix marks work that belongs to that issue, so a drive-by fix on the branch keeps its own unprefixed subject.
+- The pull-request body closes the issue with `Closes #<N>` — the `GH-<N>: ` subject prefix is not a GitHub link and closes nothing.
 - Never add a `Co-Authored-By:` trailer or any other AI attribution.
 - Keep PRs small and focused (~≤300 net LOC) with atomic commits.
 - Ensure coverage ≥90% on touched PHP paths.


### PR DESCRIPTION
Replace the in-repo commit-subject essay with a short pointer to the shared
`commit-convention` gate. The normative rule and its full rationale now live in
one self-tested place (`magicsunday/.github` `commit-convention.yml@main`); the
local branch/Closes/attribution conventions are kept, and the gate workflow
(`.github/workflows/commit-lint.yml`) is untouched.
