### PR TITLE
Add CodeRabbit review configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,66 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# Shared CodeRabbit configuration for the magicsunday/* repositories.
+# Replaces the sunset gemini-code-assist auto-review slot: an independent,
+# cross-model reviewer that runs automatically on every pull request and
+# re-reviews each new commit. It supplements — never replaces — the local
+# reviewer crew + Codex + CI gate.
+language: en-US
+early_access: false
+tone_instructions: >-
+    Senior reviewer for the magicsunday PHP/JS modules. Comment in English,
+    verify each claim against the code, and prefer correctness, security and
+    API-contract findings over style nits the linters already enforce.
+
+reviews:
+    profile: assertive
+    # Comment-only: the merge gate is the local crew + Codex + required CI checks,
+    # not the bot. Never let the bot block a merge.
+    request_changes_workflow: false
+    high_level_summary: true
+    poem: false
+    review_status: true
+    collapse_walkthrough: false
+    auto_review:
+        enabled: true
+        drafts: false
+        # Re-review on every pushed commit (the slot gemini filled): incremental
+        # review on, and the default 5-commit pause disabled so it never stops.
+        auto_incremental_review: true
+        auto_pause_after_reviewed_commits: 0
+    path_filters:
+        # Generated / vendored artefacts carry no review value and drown signal.
+        # Lockfiles are deliberately NOT excluded — a dependency change (an
+        # unexpected or typosquatted package) is exactly what a second reviewer
+        # should catch, complementing the dependency-review CI gate.
+        - "!**/.build/**"
+        - "!**/vendor/**"
+        - "!**/node_modules/**"
+        - "!**/resources/js/**/*.min.js"
+        - "!**/resources/lang/**/*.mo"
+    path_instructions:
+        - path: "src/**/*.php"
+          instructions: >-
+              Enforce the house PHP style: declare(strict_types=1); no `mixed`,
+              no `empty()`, no nested ternaries; `use function`/`use const` for
+              built-ins; never `@phpstan-ignore` (fix the type instead); every
+              method and constant needs a real PHPDoc with capitalised
+              descriptions; final readonly value objects. Flag any stdClass use.
+        - path: "tests/**/*.php"
+          instructions: >-
+              Behavioural assertions only — flag getter/setter or coverage-only
+              tests, vacuous assertions, over-mocking the unit under test, and
+              access-control tests that run as a privileged identity.
+        - path: "**/*.{js,ts,css,svg}"
+          instructions: >-
+              Enforce Biome style (4-space, double quotes, lineWidth 100),
+              `.js` extension on local ESM imports, and defensive DOM/SVG/D3
+              handling. Comments in English.
+        - path: ".github/workflows/**"
+          instructions: >-
+              Check least-privilege permissions, persist-credentials on
+              checkout, reusable-workflow permission caps, and cron/dispatch
+              concurrency races.
+
+chat:
+    auto_reply: true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 # Exclude from distribution archives (composer --prefer-dist, git archive)
+/.coderabbit.yaml      export-ignore
 /.github/              export-ignore
 .gitattributes         export-ignore
 .gitignore             export-ignore


### PR DESCRIPTION
Adds a `.coderabbit.yaml` that replaces the sunset gemini-code-assist auto-review slot with CodeRabbit — an independent, cross-model reviewer that runs automatically on every pull request and re-reviews each new commit.

It supplements, never gates: `request_changes_workflow: false` keeps the merge gate on the local reviewer crew, Codex, and the required CI checks. `path_filters` drop generated/vendored artefacts; `path_instructions` encode the house PHP/JS/test/workflow rules so the bot does not duplicate what the linters already enforce.

The file is `export-ignore`d so it never ships in the release archive.

This is the pilot for a fan-out of the same config across the magicsunday repos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added shared automated code review configuration with an assertive tone focused on correctness, security, and API-contract issues.
  * Enabled automatic reviews for pull requests, including incremental re-reviews per new commit, with draft reviews disabled.
  * Set file-specific review guidance for PHP, JS/TS/CSS/SVG, and GitHub workflows, while excluding common generated/vendored/minified assets (keeping lockfiles in scope).
  * Excluded the review configuration file from export/distribution archives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->