### PR TITLE
GH-140: Target stable webtrees on main

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "php": "8.3 - 8.5",
         "ext-dom": "*",
         "ext-json": "*",
-        "fisharebest/webtrees": "~2.2.0 || dev-main",
+        "fisharebest/webtrees": "~2.2.0",
         "magicsunday/webtrees-module-base": "^2.5",
         "magicsunday/webtrees-module-installer-plugin": "^2.0"
     },


### PR DESCRIPTION
Constrains `fisharebest/webtrees` to `~2.2.0` (dropping `|| dev-main`) so `main` resolves current **stable** webtrees — what end users install — and its CI stays green.

## Why

dev-main removed `I18N::direction()` and `I18N::scriptDirection()` in the 2026-07-15 i18n refactor (`textDirection(): TextDirection` enum now). Because a named dev version whose branch-alias outranks `2.2.6` wins even under `prefer-stable: true`, the old `~2.2.0 || dev-main` constraint always resolved dev-main, so the build broke the moment dev-main advanced past the refactor.

No code change is required — the current code already targets the 2.2.x API. dev-main tracking moves to a separate forward-compat branch (adapting to `textDirection()` via a shared helper in `webtrees-module-base`), tracked separately and promoted when webtrees ships its next stable.

Closes #140

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the supported webtrees version range to the stable 2.2 release series.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->