### PR TITLE
GH-146: Enforce the module's real layer boundaries with phpat

### DIFF
--- a/tests/Architecture/ArchitectureTest.php
+++ b/tests/Architecture/ArchitectureTest.php
@@ -19,10 +19,25 @@ use PHPat\Test\PHPat;
 /**
  * Architecture rules enforced by PHPat (runs as part of PHPStan).
  *
+ * The module is layered bottom-up: `Model` and `Configuration` are leaves,
+ * `Traits` may reach `Configuration`, `Facade` may reach `Configuration` and
+ * `Model`, and `Module` is the composition root nothing else depends on. The
+ * rules below pin exactly that, so a dependency that inverts the layering reds
+ * the build instead of quietly settling in.
+ *
+ * Note on the builder: several selectors passed to `classes()` are OR-ed, so a
+ * "everything except X" set is expressed with the dedicated `excluding()` step,
+ * never with a negated selector inside `classes()`.
+ *
  * @internal
  */
 final class ArchitectureTest
 {
+    /**
+     * The module's root namespace.
+     */
+    private const string NAMESPACE_ROOT = 'MagicSunday\Webtrees\PedigreeChart';
+
     /**
      * Every abstract class carries the `Abstract` name prefix. The pattern is
      * matched against the fully qualified name, so `[^\\]*$` pins it to the
@@ -37,5 +52,101 @@ final class ArchitectureTest
             ->classes(Selector::isAbstract())
             ->should()->beNamed('/\\\\Abstract[^\\\\]*$/', true)
             ->because('House rule: abstract classes are named Abstract<Name>.');
+    }
+
+    /**
+     * The chart node models carry data only — they must not reach back into the
+     * configuration, the facade, the traits or the module.
+     *
+     * @return Rule
+     */
+    #[TestRule]
+    public function modelIsALeaf(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT . '\\Model'))
+            ->shouldNot()->dependOn()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT))
+            ->excluding(Selector::inNamespace(self::NAMESPACE_ROOT . '\\Model'))
+            ->because('Model holds chart data; it is the bottom layer.');
+    }
+
+    /**
+     * The resolved chart configuration is a leaf as well: it reads module
+     * settings, it does not consume any other part of the module.
+     *
+     * @return Rule
+     */
+    #[TestRule]
+    public function configurationIsALeaf(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::classname(self::NAMESPACE_ROOT . '\\Configuration'))
+            ->shouldNot()->dependOn()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT))
+            ->excluding(Selector::classname(self::NAMESPACE_ROOT . '\\Configuration'))
+            ->because('Configuration is a settings holder, not a consumer of the module.');
+    }
+
+    /**
+     * The module traits are mixed into the module class and may read the
+     * configuration — but never the models, the facade or the module itself.
+     *
+     * @return Rule
+     */
+    #[TestRule]
+    public function traitsDependOnlyOnConfiguration(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT . '\\Traits'))
+            ->shouldNot()->dependOn()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT))
+            ->excluding(
+                Selector::inNamespace(self::NAMESPACE_ROOT . '\\Traits'),
+                Selector::classname(self::NAMESPACE_ROOT . '\\Configuration')
+            )
+            ->because('Traits configure the module; they may only read Configuration.');
+    }
+
+    /**
+     * The data facade builds the chart models from the resolved configuration.
+     * It must not reach the module traits or the module class.
+     *
+     * @return Rule
+     */
+    #[TestRule]
+    public function facadeDependsOnlyOnConfigurationAndModel(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT . '\\Facade'))
+            ->shouldNot()->dependOn()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT))
+            ->excluding(
+                Selector::inNamespace(self::NAMESPACE_ROOT . '\\Facade'),
+                Selector::inNamespace(self::NAMESPACE_ROOT . '\\Model'),
+                Selector::classname(self::NAMESPACE_ROOT . '\\Configuration')
+            )
+            ->because('The facade turns Configuration plus webtrees data into Model objects.');
+    }
+
+    /**
+     * The module class is the composition root — the webtrees entry point that
+     * wires the rest together. No production class may depend on it. The test
+     * namespace is excluded: a test for the module class necessarily names it.
+     *
+     * @return Rule
+     */
+    #[TestRule]
+    public function nothingDependsOnTheModule(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT))
+            ->excluding(
+                Selector::classname(self::NAMESPACE_ROOT . '\\Module'),
+                Selector::inNamespace(self::NAMESPACE_ROOT . '\\Test')
+            )
+            ->shouldNot()->dependOn()
+            ->classes(Selector::classname(self::NAMESPACE_ROOT . '\\Module'))
+            ->because('Module is the composition root; dependencies point away from it.');
     }
 }


### PR DESCRIPTION
Closes #146.

The previous change wired phpat in but left a single house-wide rule (abstract classes are named `Abstract<Name>`). This module has no abstract classes, so that rule passed vacuously and enforced nothing about *this* module's architecture. This adds the rules that carry the substance.

## The layering that is now pinned

Derived from the module's actual imports, not assumed:

| Component | may depend on |
|---|---|
| `Model\Node`, `Model\NodeData` | nothing inside the module |
| `Configuration` | nothing inside the module |
| `Traits\*` | `Configuration` |
| `Facade\DataFacade` | `Configuration`, `Model\*` |
| `Module` | the composition root — nothing depends on it |

Five rules encode exactly that, plus the retained naming rule.

## Two things worth recording

**`classes()` OR-s its selectors.** A negated selector passed alongside a positive one therefore widens the set instead of narrowing it — a first attempt at "everything except the module class" silently selected the test namespace too and produced 139 findings. The "everything except X" sets are expressed with the dedicated `excluding()` step throughout.

**The rules were proven to discriminate.** Adding a real dependency from `Model\Node` to `Configuration` makes `modelIsALeaf` fail with exactly one finding; removing it returns the suite to green. A green architecture suite that cannot fail is worth nothing, so this was verified rather than assumed.

## Out of scope

module-base additionally enforces `beFinal` on its leaf namespaces. Every class in this module is currently non-final, so those rules would fail here; finalising them is a separate change and gets its own issue.

## Verification

`composer ci:test` green (PHPStan incl. the six phpat rules, Rector, CGL, 0 clones, 11 PHP tests, 15 JS tests).
