### PR TITLE
GH-159: Align phpunit.xml to the strict canon and wire the lockstep gate

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "magicsunday/webtrees-pedigree-chart",
-    "description": "SVG pedigree chart module for the webtrees genealogy application — interactive D3.js tree visualization with multiple layouts and up to 25 generations.",
+    "description": "SVG pedigree chart module for the webtrees genealogy application \u2014 interactive D3.js tree visualization with multiple layouts and up to 25 generations.",
     "license": "GPL-3.0-or-later",
     "type": "webtrees-module",
     "keywords": [
@@ -57,7 +57,7 @@
         "magicsunday/webtrees-module-installer-plugin": "^2.0"
     },
     "require-dev": {
-        "magicsunday/coding-standard": "^1.3"
+        "magicsunday/coding-standard": "^1.4"
     },
     "autoload": {
         "psr-4": {
@@ -117,9 +117,13 @@
             "@ci:test:php:phpstan",
             "@ci:test:php:rector",
             "@ci:test:php:cpd",
+            "@ci:test:php:templates",
             "@ci:test:php:unit",
             "@ci:test:js:unit",
             "@ci:test:php:cgl"
+        ],
+        "ci:test:php:templates": [
+            "check-consumer-config.php ."
         ]
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,9 +8,13 @@
          colors="true"
          displayDetailsOnPhpunitDeprecations="true"
          executionOrder="depends,defects"
+         failOnDeprecation="true"
+         failOnNotice="true"
          failOnPhpunitDeprecation="true"
+         failOnPhpunitNotice="true"
          failOnRisky="true"
          failOnWarning="true"
+         requireCoverageMetadata="true"
 >
     <testsuites>
         <testsuite name="Unit Tests">


### PR DESCRIPTION
Closes #159.

coding-standard 1.4.0 ships a template lockstep gate asserting each consumer's copy-and-adapt template files match the strict canon. This module's `phpunit.xml` had drifted looser — missing four strict flags.

## Changes
- `magicsunday/coding-standard` → `^1.4`.
- `phpunit.xml`: add `requireCoverageMetadata`, `failOnNotice`, `failOnDeprecation`, `failOnPhpunitNotice` (suite already passes under them).
- Wire the gate as `ci:test:php:templates` and into the `ci:test` aggregate.

## Verification (buildbox, coding-standard 1.4.0)
- `ci:test:php:templates` → `OK — every present template copy matches the stable canon.`
- `ci:test:php:unit` → green under the strict flags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Quality Improvements**
  * Added automated checks for PHP template and consumer configuration issues.
  * Strengthened test validation by treating deprecations and notices as failures.
  * Tests now require code coverage metadata for improved reporting consistency.
* **Maintenance**
  * Updated the development coding-standard tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->