### PR TITLE
GH-163: Conform the module structure to the canonical Deptrac architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ __pycache__/
 
 # Playwright
 .playwright-mcp/
+/.deptrac.cache

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "magicsunday/webtrees-module-installer-plugin": "^2.0"
     },
     "require-dev": {
-        "magicsunday/coding-standard": "^1.5"
+        "magicsunday/coding-standard": "^1.6"
     },
     "autoload": {
         "psr-4": {
@@ -118,7 +118,7 @@
             "@ci:test:php:rector",
             "@ci:test:php:cpd",
             "@ci:test:php:templates",
-            "@ci:test:php:phpat-subjects",
+            "@ci:test:php:deptrac",
             "@ci:test:php:unit",
             "@ci:test:js:unit",
             "@ci:test:php:cgl"
@@ -126,8 +126,8 @@
         "ci:test:php:templates": [
             "check-consumer-config.php ."
         ],
-        "ci:test:php:phpat-subjects": [
-            "check-phpat-subjects.php ."
+        "ci:test:php:deptrac": [
+            "deptrac analyse --no-progress"
         ]
     }
 }

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -1,0 +1,30 @@
+# Deptrac configuration — imports the shared magicsunday/coding-standard ruleset.
+# This repository installs its dev tooling into .build/vendor, so the import path
+# points there (as the PHPStan include does).
+imports:
+    - .build/vendor/magicsunday/coding-standard/deptrac/layers.yaml
+
+deptrac:
+    paths:
+        - src
+
+    # `Facade\` and `Model\` are canonical (the shared directory layers cover them),
+    # and the module-behaviour traits now live under `Module\` (also directory-covered).
+    # The `Module` and `Configuration` entry classes stay at the source root — a single
+    # class is its own layer, and moving it into a same-named subdirectory would only
+    # produce a redundant `Module/Module.php` and churn the entry FQCN — so each is
+    # mapped to its canonical layer by an exact FQCN (which cannot collide with a vendor
+    # class).
+    layers:
+        -
+            name: Module
+            collectors:
+                -
+                    type: classNameRegex
+                    value: '#^MagicSunday\\Webtrees\\PedigreeChart\\Module$#'
+        -
+            name: Configuration
+            collectors:
+                -
+                    type: classNameRegex
+                    value: '#^MagicSunday\\Webtrees\\PedigreeChart\\Configuration$#'

--- a/resources/lang/cs/messages.po
+++ b/resources/lang/cs/messages.po
@@ -163,7 +163,7 @@ msgstr "Otcovská"
 msgid "Pedigree chart"
 msgstr "Diagram předků"
 
-#: src/Module.php:248 src/Traits/ModuleChartTrait.php:43
+#: src/Module.php:248 src/Module/ChartTrait.php:44
 #, php-format
 msgid "Pedigree chart of %s"
 msgstr "Diagram předků osoby %s"
@@ -200,7 +200,7 @@ msgstr "Zobrazit přezdívky ve zobrazovaných jménech"
 msgid "Switch between full screen mode and normal view"
 msgstr "Přepnout mezi celou obrazovkou a normálním zobrazením"
 
-#: src/Traits/ModuleConfigTrait.php:111
+#: src/Module/ConfigTrait.php:113
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""

--- a/resources/lang/da/messages.po
+++ b/resources/lang/da/messages.po
@@ -163,7 +163,7 @@ msgstr "Fædrene"
 msgid "Pedigree chart"
 msgstr "Stamtavle"
 
-#: src/Module.php:248 src/Traits/ModuleChartTrait.php:43
+#: src/Module.php:248 src/Module/ChartTrait.php:44
 #, php-format
 msgid "Pedigree chart of %s"
 msgstr "Stamtavle for %s"
@@ -200,7 +200,7 @@ msgstr "Vis kælenavne i visningsnavne"
 msgid "Switch between full screen mode and normal view"
 msgstr "Skift mellem fuldskærms- og normal visning"
 
-#: src/Traits/ModuleConfigTrait.php:111
+#: src/Module/ConfigTrait.php:113
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""

--- a/resources/lang/de/messages.po
+++ b/resources/lang/de/messages.po
@@ -170,7 +170,7 @@ msgstr "Väterlich"
 msgid "Pedigree chart"
 msgstr "Vorfahrentafel"
 
-#: src/Module.php:248 src/Traits/ModuleChartTrait.php:43
+#: src/Module.php:248 src/Module/ChartTrait.php:44
 #, php-format
 msgid "Pedigree chart of %s"
 msgstr "Vorfahrentafel von %s"
@@ -207,7 +207,7 @@ msgstr "Spitznamen in den angezeigten Namen anzeigen"
 msgid "Switch between full screen mode and normal view"
 msgstr "Zwischen Vollbildmodus und normaler Ansicht umschalten"
 
-#: src/Traits/ModuleConfigTrait.php:111
+#: src/Module/ConfigTrait.php:113
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""

--- a/resources/lang/en-GB/messages.po
+++ b/resources/lang/en-GB/messages.po
@@ -163,7 +163,7 @@ msgstr "Paternal"
 msgid "Pedigree chart"
 msgstr "Pedigree chart"
 
-#: src/Module.php:248 src/Traits/ModuleChartTrait.php:43
+#: src/Module.php:248 src/Module/ChartTrait.php:44
 #, php-format
 msgid "Pedigree chart of %s"
 msgstr "Pedigree chart of %s"
@@ -200,7 +200,7 @@ msgstr "Show nicknames in display names"
 msgid "Switch between full screen mode and normal view"
 msgstr "Switch between full screen mode and normal view"
 
-#: src/Traits/ModuleConfigTrait.php:111
+#: src/Module/ConfigTrait.php:113
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr "The preferences for the module “%s” have been updated."

--- a/resources/lang/en-US/messages.po
+++ b/resources/lang/en-US/messages.po
@@ -164,7 +164,7 @@ msgstr "Paternal"
 msgid "Pedigree chart"
 msgstr "Pedigree chart"
 
-#: src/Module.php:248 src/Traits/ModuleChartTrait.php:43
+#: src/Module.php:248 src/Module/ChartTrait.php:44
 #, php-format
 msgid "Pedigree chart of %s"
 msgstr "Pedigree chart of %s"
@@ -201,7 +201,7 @@ msgstr "Show nicknames in display names"
 msgid "Switch between full screen mode and normal view"
 msgstr "Switch between full screen mode and normal view"
 
-#: src/Traits/ModuleConfigTrait.php:111
+#: src/Module/ConfigTrait.php:113
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr "The preferences for the module “%s” have been updated."

--- a/resources/lang/es/messages.po
+++ b/resources/lang/es/messages.po
@@ -165,7 +165,7 @@ msgstr "Paterno"
 msgid "Pedigree chart"
 msgstr "Árbol de antepasados"
 
-#: src/Module.php:248 src/Traits/ModuleChartTrait.php:43
+#: src/Module.php:248 src/Module/ChartTrait.php:44
 #, php-format
 msgid "Pedigree chart of %s"
 msgstr "Árbol de antepasados de %s"
@@ -202,7 +202,7 @@ msgstr "Mostrar apodos en los nombres mostrados"
 msgid "Switch between full screen mode and normal view"
 msgstr "Cambiar entre pantalla completa y vista normal"
 
-#: src/Traits/ModuleConfigTrait.php:111
+#: src/Module/ConfigTrait.php:113
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""

--- a/resources/lang/fr/messages.po
+++ b/resources/lang/fr/messages.po
@@ -165,7 +165,7 @@ msgstr "Paternelle"
 msgid "Pedigree chart"
 msgstr "Arbre d'ascendance"
 
-#: src/Module.php:248 src/Traits/ModuleChartTrait.php:43
+#: src/Module.php:248 src/Module/ChartTrait.php:44
 #, php-format
 msgid "Pedigree chart of %s"
 msgstr "Arbre généalogique de %s"
@@ -203,7 +203,7 @@ msgstr "Afficher les surnoms dans les noms affichés"
 msgid "Switch between full screen mode and normal view"
 msgstr "Basculer entre le plein écran et la vue normale"
 
-#: src/Traits/ModuleConfigTrait.php:111
+#: src/Module/ConfigTrait.php:113
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""

--- a/resources/lang/is/messages.po
+++ b/resources/lang/is/messages.po
@@ -167,7 +167,7 @@ msgstr "Föður"
 msgid "Pedigree chart"
 msgstr "Ættartölugraf"
 
-#: src/Module.php:248 src/Traits/ModuleChartTrait.php:43
+#: src/Module.php:248 src/Module/ChartTrait.php:44
 #, php-format
 msgid "Pedigree chart of %s"
 msgstr "Ættartölugraf fyrir %s"
@@ -204,7 +204,7 @@ msgstr "Sýna gælunöfn í birtingarnafni"
 msgid "Switch between full screen mode and normal view"
 msgstr "Skiptu á milli fullsskjás og venjulegs skjás"
 
-#: src/Traits/ModuleConfigTrait.php:111
+#: src/Module/ConfigTrait.php:113
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr "Kjörstillingar fyrir eininguna “%s“ hafa verið uppfærðar."

--- a/resources/lang/nb/messages.po
+++ b/resources/lang/nb/messages.po
@@ -167,7 +167,7 @@ msgstr "Fars"
 msgid "Pedigree chart"
 msgstr "Anediagram"
 
-#: src/Module.php:248 src/Traits/ModuleChartTrait.php:43
+#: src/Module.php:248 src/Module/ChartTrait.php:44
 #, php-format
 msgid "Pedigree chart of %s"
 msgstr "Anediagram for %s"
@@ -204,7 +204,7 @@ msgstr "Vis kallenavn i visningsnavn"
 msgid "Switch between full screen mode and normal view"
 msgstr "Bytt mellom fullskjerm og normal visning"
 
-#: src/Traits/ModuleConfigTrait.php:111
+#: src/Module/ConfigTrait.php:113
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr "Innstillingene for modulen “%s” har blitt oppdatert."

--- a/resources/lang/nl/messages.po
+++ b/resources/lang/nl/messages.po
@@ -170,7 +170,7 @@ msgstr "Vaderlijk"
 msgid "Pedigree chart"
 msgstr "Kwartierstaat"
 
-#: src/Module.php:248 src/Traits/ModuleChartTrait.php:43
+#: src/Module.php:248 src/Module/ChartTrait.php:44
 #, php-format
 msgid "Pedigree chart of %s"
 msgstr "Kwartierstaat van %s"
@@ -207,7 +207,7 @@ msgstr "Toon bijnamen in weergavenamen"
 msgid "Switch between full screen mode and normal view"
 msgstr "Schakelen tussen volledig scherm en normale weergave"
 
-#: src/Traits/ModuleConfigTrait.php:111
+#: src/Module/ConfigTrait.php:113
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr "De voorkeuren voor de module \"%s\" zijn bijgewerkt."

--- a/resources/lang/nn/messages.po
+++ b/resources/lang/nn/messages.po
@@ -167,7 +167,7 @@ msgstr "Fars"
 msgid "Pedigree chart"
 msgstr "Anediagram"
 
-#: src/Module.php:248 src/Traits/ModuleChartTrait.php:43
+#: src/Module.php:248 src/Module/ChartTrait.php:44
 #, php-format
 msgid "Pedigree chart of %s"
 msgstr "Anediagram for %s"
@@ -204,7 +204,7 @@ msgstr "Vis kallenamn i visningsnamn"
 msgid "Switch between full screen mode and normal view"
 msgstr "Byt mellom fullskjerm og normal visning"
 
-#: src/Traits/ModuleConfigTrait.php:111
+#: src/Module/ConfigTrait.php:113
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr "Innstillingane for modulen “%s” har blitt oppdatert."

--- a/resources/lang/ru/messages.po
+++ b/resources/lang/ru/messages.po
@@ -164,7 +164,7 @@ msgstr "Отцовский"
 msgid "Pedigree chart"
 msgstr "Восходящее дерево"
 
-#: src/Module.php:248 src/Traits/ModuleChartTrait.php:43
+#: src/Module.php:248 src/Module/ChartTrait.php:44
 #, php-format
 msgid "Pedigree chart of %s"
 msgstr "Восходящее дерево %s"
@@ -201,7 +201,7 @@ msgstr "Показывать прозвища в отображаемых име
 msgid "Switch between full screen mode and normal view"
 msgstr "Переключение между полноэкранным и обычным режимом"
 
-#: src/Traits/ModuleConfigTrait.php:111
+#: src/Module/ConfigTrait.php:113
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""

--- a/resources/lang/sk/messages.po
+++ b/resources/lang/sk/messages.po
@@ -166,7 +166,7 @@ msgstr "Otcovská"
 msgid "Pedigree chart"
 msgstr "Rodokmeň"
 
-#: src/Module.php:248 src/Traits/ModuleChartTrait.php:43
+#: src/Module.php:248 src/Module/ChartTrait.php:44
 #, php-format
 msgid "Pedigree chart of %s"
 msgstr "Rodokmeň %s"
@@ -203,7 +203,7 @@ msgstr "Zobraziť prezývky v zobrazovaných menách"
 msgid "Switch between full screen mode and normal view"
 msgstr "Prepnúť medzi celou obrazovkou a normálnym zobrazením"
 
-#: src/Traits/ModuleConfigTrait.php:111
+#: src/Module/ConfigTrait.php:113
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""

--- a/resources/lang/sl/messages.po
+++ b/resources/lang/sl/messages.po
@@ -170,7 +170,7 @@ msgstr "Očetova"
 msgid "Pedigree chart"
 msgstr "Rodovnik"
 
-#: src/Module.php:248 src/Traits/ModuleChartTrait.php:43
+#: src/Module.php:248 src/Module/ChartTrait.php:44
 #, php-format
 msgid "Pedigree chart of %s"
 msgstr "Rodovnik osebe %s"
@@ -207,7 +207,7 @@ msgstr "Prikaži vzdevke v prikaznih imenih"
 msgid "Switch between full screen mode and normal view"
 msgstr "Preklopi med celozaslonskim in običajnim načinom"
 
-#: src/Traits/ModuleConfigTrait.php:111
+#: src/Module/ConfigTrait.php:113
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr "Nastavitve modula “%s” so posodobljene."

--- a/resources/lang/sv/messages.po
+++ b/resources/lang/sv/messages.po
@@ -163,7 +163,7 @@ msgstr "Faderns"
 msgid "Pedigree chart"
 msgstr "Antavla"
 
-#: src/Module.php:248 src/Traits/ModuleChartTrait.php:43
+#: src/Module.php:248 src/Module/ChartTrait.php:44
 #, php-format
 msgid "Pedigree chart of %s"
 msgstr "Antavla för %s"
@@ -200,7 +200,7 @@ msgstr "Visa smeknamn i visningsnamn"
 msgid "Switch between full screen mode and normal view"
 msgstr "Växla mellan helskärm och normal vy"
 
-#: src/Traits/ModuleConfigTrait.php:111
+#: src/Module/ConfigTrait.php:113
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""

--- a/resources/lang/uk/messages.po
+++ b/resources/lang/uk/messages.po
@@ -164,7 +164,7 @@ msgstr "Батьківський"
 msgid "Pedigree chart"
 msgstr "Родовід"
 
-#: src/Module.php:248 src/Traits/ModuleChartTrait.php:43
+#: src/Module.php:248 src/Module/ChartTrait.php:44
 #, php-format
 msgid "Pedigree chart of %s"
 msgstr "Родовід для %s"
@@ -201,7 +201,7 @@ msgstr "Показувати прізвиська у відображувани�
 msgid "Switch between full screen mode and normal view"
 msgstr "Перемикання між повноекранним і звичайним режимом"
 
-#: src/Traits/ModuleConfigTrait.php:111
+#: src/Module/ConfigTrait.php:113
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""

--- a/resources/lang/vi/messages.po
+++ b/resources/lang/vi/messages.po
@@ -163,7 +163,7 @@ msgstr "Bên nội"
 msgid "Pedigree chart"
 msgstr "Biểu đồ phả hệ"
 
-#: src/Module.php:248 src/Traits/ModuleChartTrait.php:43
+#: src/Module.php:248 src/Module/ChartTrait.php:44
 #, php-format
 msgid "Pedigree chart of %s"
 msgstr "Biểu đồ phả hệ của %s"
@@ -200,7 +200,7 @@ msgstr "Hiển thị biệt danh trong tên hiển thị"
 msgid "Switch between full screen mode and normal view"
 msgstr "Chuyển giữa toàn màn hình và xem bình thường"
 
-#: src/Traits/ModuleConfigTrait.php:111
+#: src/Module/ConfigTrait.php:113
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""

--- a/resources/lang/zh-Hans/messages.po
+++ b/resources/lang/zh-Hans/messages.po
@@ -161,7 +161,7 @@ msgstr "父系"
 msgid "Pedigree chart"
 msgstr "世系图"
 
-#: src/Module.php:248 src/Traits/ModuleChartTrait.php:43
+#: src/Module.php:248 src/Module/ChartTrait.php:44
 #, php-format
 msgid "Pedigree chart of %s"
 msgstr "%s的世系图"
@@ -198,7 +198,7 @@ msgstr "在显示名中显示昵称"
 msgid "Switch between full screen mode and normal view"
 msgstr "切换全屏与普通视图"
 
-#: src/Traits/ModuleConfigTrait.php:111
+#: src/Module/ConfigTrait.php:113
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""

--- a/resources/lang/zh-Hant/messages.po
+++ b/resources/lang/zh-Hant/messages.po
@@ -161,7 +161,7 @@ msgstr "父系"
 msgid "Pedigree chart"
 msgstr "世系圖"
 
-#: src/Module.php:248 src/Traits/ModuleChartTrait.php:43
+#: src/Module.php:248 src/Module/ChartTrait.php:44
 #, php-format
 msgid "Pedigree chart of %s"
 msgstr "%s的世系圖"
@@ -198,7 +198,7 @@ msgstr "在顯示名中顯示暱稱"
 msgid "Switch between full screen mode and normal view"
 msgstr "切換全螢幕與一般檢視"
 
-#: src/Traits/ModuleConfigTrait.php:111
+#: src/Module/ConfigTrait.php:113
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""

--- a/src/Module.php
+++ b/src/Module.php
@@ -30,8 +30,8 @@ use Fisharebest\Webtrees\View;
 use MagicSunday\Webtrees\ModuleBase\Contract\ModuleAssetUrlInterface;
 use MagicSunday\Webtrees\ModuleBase\Traits\ModuleCustomTrait;
 use MagicSunday\Webtrees\PedigreeChart\Facade\DataFacade;
-use MagicSunday\Webtrees\PedigreeChart\Traits\ModuleChartTrait;
-use MagicSunday\Webtrees\PedigreeChart\Traits\ModuleConfigTrait;
+use MagicSunday\Webtrees\PedigreeChart\Module\ChartTrait;
+use MagicSunday\Webtrees\PedigreeChart\Module\ConfigTrait;
 use Override;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -46,8 +46,8 @@ use Psr\Http\Message\ServerRequestInterface;
 class Module extends PedigreeChartModule implements ModuleAssetUrlInterface, ModuleCustomInterface, ModuleConfigInterface
 {
     use ModuleCustomTrait;
-    use ModuleChartTrait;
-    use ModuleConfigTrait;
+    use ChartTrait;
+    use ConfigTrait;
 
     private const string ROUTE_DEFAULT = 'webtrees-pedigree-chart';
 

--- a/src/Module/ChartTrait.php
+++ b/src/Module/ChartTrait.php
@@ -9,20 +9,21 @@
 
 declare(strict_types=1);
 
-namespace MagicSunday\Webtrees\PedigreeChart\Traits;
+namespace MagicSunday\Webtrees\PedigreeChart\Module;
 
 use Fisharebest\Webtrees\I18N;
 use Fisharebest\Webtrees\Individual;
 use MagicSunday\Webtrees\ModuleBase\Traits\ModuleChartTrait as BaseModuleChartTrait;
 
 /**
- * Trait ModuleChartTrait.
+ * Implements the webtrees ModuleChartInterface methods specific to the pedigree
+ * chart: menu CSS class and chart title.
  *
  * @author  Rico Sonntag <mail@ricosonntag.de>
  * @license https://opensource.org/licenses/GPL-3.0 GNU General Public License v3.0
  * @link    https://github.com/magicsunday/webtrees-pedigree-chart/
  */
-trait ModuleChartTrait
+trait ChartTrait
 {
     use BaseModuleChartTrait;
 

--- a/src/Module/ConfigTrait.php
+++ b/src/Module/ConfigTrait.php
@@ -9,24 +9,26 @@
 
 declare(strict_types=1);
 
-namespace MagicSunday\Webtrees\PedigreeChart\Traits;
+namespace MagicSunday\Webtrees\PedigreeChart\Module;
 
 use Fisharebest\Webtrees\FlashMessages;
 use Fisharebest\Webtrees\I18N;
+use Fisharebest\Webtrees\Module\ModuleConfigTrait;
 use MagicSunday\Webtrees\PedigreeChart\Configuration;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
- * Trait ModuleConfigTrait.
+ * Provides the admin configuration page (GET) and the preference-save action
+ * (POST) for the pedigree chart module's control-panel settings.
  *
  * @author  Rico Sonntag <mail@ricosonntag.de>
  * @license https://opensource.org/licenses/GPL-3.0 GNU General Public License v3.0
  * @link    https://github.com/magicsunday/webtrees-pedigree-chart/
  */
-trait ModuleConfigTrait
+trait ConfigTrait
 {
-    use \Fisharebest\Webtrees\Module\ModuleConfigTrait;
+    use ModuleConfigTrait;
 
     /**
      * @param ServerRequestInterface $request

--- a/tests/Architecture/ArchitectureTest.php
+++ b/tests/Architecture/ArchitectureTest.php
@@ -19,36 +19,24 @@ use PHPat\Test\PHPat;
 /**
  * Architecture rules enforced by PHPat (runs as part of PHPStan).
  *
- * The module is layered bottom-up: `Model` and `Configuration` are leaves,
- * `Traits` may reach `Configuration`, `Facade` may reach `Configuration` and
- * `Model`, and `Module` is the composition root nothing else depends on. The
- * rules below pin exactly that, so a dependency that inverts the layering reds
- * the build instead of quietly settling in.
- *
- * Note on the builder: several selectors passed to `classes()` are OR-ed, so a
- * "everything except X" set is expressed with the dedicated `excluding()` step,
- * never with a negated selector inside `classes()`.
- *
- * Scope limit: the `Traits` layer cannot be the SUBJECT of a rule. phpat resolves
- * a subject through PHPStan's `InClassNode`, which never fires for a trait on its
- * own, so such a rule matches nothing and passes green regardless — it would imply
- * coverage that does not exist. The traits stay pinned in the incoming direction
- * (the leaf rules below forbid the other layers from depending on them); only
- * their outgoing dependencies are unenforceable here.
+ * The layer-DEPENDENCY directions — the permissive canonical-layer ruleset,
+ * within which nothing may depend on the composition root — are now enforced
+ * centrally by the shared Deptrac ruleset (`deptrac.yaml` imports
+ * `magicsunday/coding-standard`'s canonical layers). What remains here is the one
+ * structural invariant Deptrac's layer model cannot express.
  *
  * @internal
  */
 final class ArchitectureTest
 {
     /**
-     * The module's root namespace.
-     */
-    private const string NAMESPACE_ROOT = 'MagicSunday\Webtrees\PedigreeChart';
-
-    /**
      * Every abstract class carries the `Abstract` name prefix. The pattern is
      * matched against the fully qualified name, so `[^\\]*$` pins it to the
      * short class name rather than any namespace segment.
+     *
+     * The module currently declares no abstract class, so this rule selects no
+     * subjects and passes vacuously today — it is a forward guard that reds the
+     * first mis-named abstract class introduced later, not adopted coverage.
      *
      * @return Rule
      */
@@ -59,81 +47,5 @@ final class ArchitectureTest
             ->classes(Selector::isAbstract())
             ->should()->beNamed('/\\\\Abstract[^\\\\]*$/', true)
             ->because('House rule: abstract classes are named Abstract<Name>.');
-    }
-
-    /**
-     * The chart node models carry data only — they must not reach back into the
-     * configuration, the facade, the traits or the module.
-     *
-     * @return Rule
-     */
-    #[TestRule]
-    public function modelIsALeaf(): Rule
-    {
-        return PHPat::rule()
-            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT . '\\Model'))
-            ->shouldNot()->dependOn()
-            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT))
-            ->excluding(Selector::inNamespace(self::NAMESPACE_ROOT . '\\Model'))
-            ->because('Model holds chart data; it is the bottom layer.');
-    }
-
-    /**
-     * The resolved chart configuration is a leaf as well: it reads module
-     * settings, it does not consume any other part of the module.
-     *
-     * @return Rule
-     */
-    #[TestRule]
-    public function configurationIsALeaf(): Rule
-    {
-        return PHPat::rule()
-            ->classes(Selector::classname(self::NAMESPACE_ROOT . '\\Configuration'))
-            ->shouldNot()->dependOn()
-            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT))
-            ->excluding(Selector::classname(self::NAMESPACE_ROOT . '\\Configuration'))
-            ->because('Configuration is a settings holder, not a consumer of the module.');
-    }
-
-    /**
-     * The data facade builds the chart models from the resolved configuration.
-     * It must not reach the module traits or the module class.
-     *
-     * @return Rule
-     */
-    #[TestRule]
-    public function facadeDependsOnlyOnConfigurationAndModel(): Rule
-    {
-        return PHPat::rule()
-            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT . '\\Facade'))
-            ->shouldNot()->dependOn()
-            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT))
-            ->excluding(
-                Selector::inNamespace(self::NAMESPACE_ROOT . '\\Facade'),
-                Selector::inNamespace(self::NAMESPACE_ROOT . '\\Model'),
-                Selector::classname(self::NAMESPACE_ROOT . '\\Configuration')
-            )
-            ->because('The facade turns Configuration plus webtrees data into Model objects.');
-    }
-
-    /**
-     * The module class is the composition root — the webtrees entry point that
-     * wires the rest together. No production class may depend on it. The test
-     * namespace is excluded: a test for the module class necessarily names it.
-     *
-     * @return Rule
-     */
-    #[TestRule]
-    public function nothingDependsOnTheModule(): Rule
-    {
-        return PHPat::rule()
-            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT))
-            ->excluding(
-                Selector::classname(self::NAMESPACE_ROOT . '\\Module'),
-                Selector::inNamespace(self::NAMESPACE_ROOT . '\\Test')
-            )
-            ->shouldNot()->dependOn()
-            ->classes(Selector::classname(self::NAMESPACE_ROOT . '\\Module'))
-            ->because('Module is the composition root; dependencies point away from it.');
     }
 }

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -218,7 +218,7 @@ final class ConfigurationTest extends TestCase
 
     /**
      * The persisting path is POST:
-     * {@see \MagicSunday\Webtrees\PedigreeChart\Traits\ModuleConfigTrait::postAdminAction()}
+     * {@see Module\ConfigTrait::postAdminAction()}
      * reads the value from the request body, so the POST branch of
      * getNameAbbreviation() (Validator::parsedBody) must resolve the same way as
      * the GET branch — the request body wins over the module preference. A


### PR DESCRIPTION
Adopts the shared `magicsunday/coding-standard` Deptrac ruleset and conforms the module's physical structure to the canonical layer model, replacing the module's bespoke phpat layer rules.

## Changes
- **Trait relocation** — `src/Traits/ModuleChartTrait.php` → `src/Module/ChartTrait.php` (`trait ChartTrait`) and `src/Traits/ModuleConfigTrait.php` → `src/Module/ConfigTrait.php` (`trait ConfigTrait`), namespace `…\PedigreeChart\Module`. Bodies are byte-identical; only wrapper name and namespace change. `src/Module.php` trait wiring updated accordingly.
- **`deptrac.yaml`** — imports the shared canonical `deptrac/layers.yaml`; the root entry classes (`Module`, `Configuration`) stay at the source root and are mapped onto their canonical layers by exact-FQCN collectors (the `Facade\`/`Model\`/`Module\` directories are covered by the shared directory collectors).
- **`ArchitectureTest.php`** — reduced to the one structural invariant Deptrac's layer model cannot express (`abstractClassesAreAbstractPrefixed`, labelled as a forward guard). The layer-dependency directions now live centrally in the shared Deptrac ruleset.
- **`composer.json`** — `coding-standard` `^1.5` → `^1.6`; the `ci:test:php:phpat-subjects` step is replaced by `ci:test:php:deptrac`.
- **PO catalogues** — 19 catalogues regenerated (source-location `#:` comments only; no msgid/msgstr/fuzzy drift).

## Verification
- `composer ci:test:php:phpstan` (incl. phpat) — no errors
- `composer ci:test:php:unit` — 11 tests, 13 assertions, OK
- `deptrac analyse` (verified outside the vendored checkout) — 0 violations, 0 warnings, 0 errors

Closes #163

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved and renamed module chart and configuration components into the module namespace while keeping existing behavior unchanged.
  * Updated translation source references to match the component reorganization (no translation text changes).

* **Chores**
  * Added repository architectural dependency checks via a shared Deptrac configuration and enabled Deptrac analysis in CI.
  * Bumped coding-standard tooling and ignored the Deptrac analysis cache in version control.

* **Tests**
  * Adjusted the architecture test to align with the new centralized Deptrac enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->