### PR TITLE
Validate GH-30 reusable workflow change (temporary, will not merge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     # in one place. Copy-paste detection stays below: jscpd is a Node tool and
     # needs this repository's JS lane.
     php:
-        uses: magicsunday/.github/.github/workflows/php-quality.yml@main
+        uses: magicsunday/.github/.github/workflows/php-quality.yml@GH-30
         permissions:
             contents: read
 


### PR DESCRIPTION
Temporary validation PR per magicsunday/.github AGENTS.md's workflow-file-change rule: points this repo's php-quality.yml reference at GH-30 to exercise the new Composer caching step on real CI before that PR merges. Will be closed without merging and the branch deleted once CI is confirmed green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the PHP quality checks to use the latest shared workflow configuration.
  * No changes to application functionality or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->