### PR TITLE
GH-174: Add the AI issue labeler thin caller

### DIFF
--- a/.github/workflows/issue-labels.yml
+++ b/.github/workflows/issue-labels.yml
@@ -1,0 +1,31 @@
+name: Issue labels
+
+# Thin caller for the reusable AI issue labeler
+# (magicsunday/.github's ai-issue-labeler.yml). See that workflow's own
+# header comment for the full contract (label-set enum constraint,
+# needs-triage fallback, residual-risk acceptance).
+#
+# `uses: magicsunday/.github/.github/workflows/ai-issue-labeler.yml@main`
+# (the fully-qualified form) - a caller in a DIFFERENT repository than the
+# one that owns the reusable workflow, per that workflow's own documented
+# CALLER REQUIREMENTS block.
+#
+# REQUIRES the `ANTHROPIC_API_KEY` repository secret to be set on THIS repo
+# - this account has no org-wide secret inheritance (see
+# ai-issue-labeler.yml's own header comment for what happens, and its own
+# fail-loudly contract, when the secret is missing or invalid). That
+# failure is harmless here: it never blocks issue creation itself, since
+# `issues: write` is the only permission this caller grants.
+on:
+    issues:
+        types: [opened]
+
+permissions: {}
+
+jobs:
+    label:
+        uses: magicsunday/.github/.github/workflows/ai-issue-labeler.yml@main
+        permissions:
+            issues: write
+        secrets:
+            anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
Adds a thin caller workflow for `magicsunday/.github`'s reusable `ai-issue-labeler.yml` workflow, which classifies newly-opened issues via the Anthropic API and applies a label from this repo's own live label set, falling back to `needs-triage` on low confidence.

Part of the multi-repo rollout tracked in `magicsunday/.github#60`, step 4. The workflow has already been piloted end-to-end (verified working, including a real cross-repo test) in `magicsunday/.github` itself and in `magicsunday/coding-standard`.

This repo already has an `ANTHROPIC_API_KEY` repository secret provisioned and a `needs-triage` label.

Closes #174.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow that labels newly opened issues.
  * The workflow uses AI-assisted labeling with restricted issue-write permissions and a configured API secret.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->